### PR TITLE
Support RGBA hex color values in XML spell checker

### DIFF
--- a/spellchecker/src/com/intellij/spellchecker/tokenizer/SpellcheckingStrategy.java
+++ b/spellchecker/src/com/intellij/spellchecker/tokenizer/SpellcheckingStrategy.java
@@ -116,7 +116,7 @@ public class SpellcheckingStrategy {
 
       final String valueTextTrimmed = element.getValue().trim();
       // do not inspect colors like #00aaFF
-      if (valueTextTrimmed.startsWith("#") && valueTextTrimmed.length() <= 7 && isHexString(valueTextTrimmed.substring(1))) {
+      if (valueTextTrimmed.startsWith("#") && valueTextTrimmed.length() <= 9 && isHexString(valueTextTrimmed.substring(1))) {
         return;
       }
 


### PR DESCRIPTION
Previously, only RGB color values were supported.
 See PR 1317 in origin repo