### PR TITLE
[Gradle] Avoid ConcurrentModificationException

### DIFF
--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/builder/ExternalTestsModelBuilderImpl.groovy
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/builder/ExternalTestsModelBuilderImpl.groovy
@@ -37,7 +37,9 @@ class ExternalTestsModelBuilderImpl implements ModelBuilderService {
 
   private static List<ExternalTestSourceMapping> getMapping(Project project) {
     def taskToClassesDirs = new LinkedHashMap<Test, Set<String>>()
-    for (task in project.tasks.withType(Test.class)) {
+    def taskIterator = project.tasks.withType(Test.class).iterator()
+    while (taskIterator.hasNext()) {
+      def task = taskIterator.next()
       taskToClassesDirs.put(task, getClassesDirs(task))
     }
 


### PR DESCRIPTION
Use iterator to access task collection instead of iterating the collection directly, the later would
cause ConcurrentModificationException if the items are changed during iteration.
 See PR 1307 in origin repo