### PR TITLE
[IDEA-232518] The balloon panel of a breakpoint is not FocusCycleRoot

### DIFF
--- a/community-guitests/testSrc/com/intellij/testGuiFramework/tests/community/focus/BreakpointBalloonFocusTest.kt
+++ b/community-guitests/testSrc/com/intellij/testGuiFramework/tests/community/focus/BreakpointBalloonFocusTest.kt
@@ -1,0 +1,98 @@
+// Copyright 2000-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.intellij.testGuiFramework.tests.community.focus
+
+import com.intellij.testGuiFramework.fixtures.FileEditorFixture
+import com.intellij.testGuiFramework.impl.GuiTestCase
+import com.intellij.testGuiFramework.tests.community.CommunityProjectCreator
+import com.intellij.testGuiFramework.util.Key
+import org.fest.swing.core.SmartWaitRobot
+import org.fest.swing.timing.Pause
+import org.junit.Test
+import java.awt.Component
+import java.awt.Container
+import javax.swing.FocusManager
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class BreakpointBalloonFocusTest : GuiTestCase() {
+
+  private val NUMBER_OF_ELEMENTS_IN_BALLOON = 6
+
+  @Test
+  fun testFocusBreakpoint() {
+    CommunityProjectCreator.importCommandLineAppAndOpenMain()
+    Pause.pause(1000)
+    ideFrame {
+      editor {
+        prepareEditor()
+        openDebuggerBalloon()
+        assertDebuggerBalloonInFocus()
+        closeDebuggerBalloon()
+        assertEditorInFocus()
+      }
+    }
+  }
+
+  private fun openDebuggerBalloon() {
+    shortcut("control f8")
+    shortcut("control shift f8")
+  }
+
+  private fun closeDebuggerBalloon() {
+    shortcut("control ENTER")
+  }
+
+  private fun FileEditorFixture.prepareEditor() {
+    val fastRobot = robot() as SmartWaitRobot
+    moveTo(89)
+    fastRobot.fastTyping("int i = 0;")
+  }
+
+  private fun assertDebuggerBalloonInFocus() {
+    with(FocusManager.getCurrentManager()) {
+      val originalFocusCycleRoot = currentFocusCycleRoot
+      var prevFocusOwner = focusOwner
+
+      // round trip over all the elements in the debugger balloon and go back to the condition field
+      repeat(NUMBER_OF_ELEMENTS_IN_BALLOON) {
+        shortcut(Key.TAB)
+
+        assertTabMovesFocus(prevFocusOwner)
+        assertFocusCycleRootSame(originalFocusCycleRoot)
+
+        prevFocusOwner = focusOwner
+      }
+    }
+
+    val fastRobot = robot() as SmartWaitRobot
+    fastRobot.fastTyping("true");
+  }
+
+  private fun FocusManager.assertFocusCycleRootSame(balloon: Container?) {
+    assertEquals(
+      currentFocusCycleRoot,
+      balloon,
+      "The debugger balloon cannot lose focus while traversing it"
+    )
+  }
+
+  private fun FocusManager.assertTabMovesFocus(prevFocusOwner: Component?) {
+    assertNotEquals(
+      prevFocusOwner,
+      focusOwner,
+      "TAB should move focus to a different element in the debugger balloon"
+    )
+  }
+
+  private fun FileEditorFixture.assertEditorInFocus() {
+    with(FocusManager.getCurrentManager()) {
+      with (editor) {
+        assertEquals(
+          focusOwner,
+          contentComponent,
+          "The editor has to grab focus after the debugger balloon disappears"
+        )
+      }
+    }
+  }
+}

--- a/platform/platform-impl/src/com/intellij/ui/BalloonImpl.java
+++ b/platform/platform-impl/src/com/intellij/ui/BalloonImpl.java
@@ -1713,11 +1713,6 @@ public final class BalloonImpl implements Balloon, IdeTooltip.Ui, ScreenAreaCons
       putClientProperty(UIUtil.TEXT_COPY_ROOT, Boolean.TRUE);
       myBalloon = balloon;
 
-      // When a screen reader is active, TAB/Shift-TAB should allow moving the focus
-      // outside the balloon in the event the balloon acquired the focus.
-      if (!ScreenReader.isActive()) {
-        setFocusCycleRoot(true);
-      }
       putClientProperty(Balloon.KEY, BalloonImpl.this);
 
       myContent = new JPanel(new BorderLayout(2, 2));
@@ -1733,34 +1728,9 @@ public final class BalloonImpl implements Balloon, IdeTooltip.Ui, ScreenAreaCons
       myContent.setBorder(shapeBorder);
       myContent.setOpaque(false);
 
+      myContent.setFocusCycleRoot(true);
+
       add(myContent);
-      setFocusTraversalPolicyProvider(true);
-      setFocusTraversalPolicy(new FocusTraversalPolicy() {
-        @Override
-        public Component getComponentAfter(Container aContainer, Component aComponent) {
-          return WeakFocusStackManager.getInstance().getLastFocusedOutside(MyComponent.this);
-        }
-
-        @Override
-        public Component getComponentBefore(Container aContainer, Component aComponent) {
-          return WeakFocusStackManager.getInstance().getLastFocusedOutside(MyComponent.this);
-        }
-
-        @Override
-        public Component getFirstComponent(Container aContainer) {
-          return WeakFocusStackManager.getInstance().getLastFocusedOutside(MyComponent.this);
-        }
-
-        @Override
-        public Component getLastComponent(Container aContainer) {
-          return WeakFocusStackManager.getInstance().getLastFocusedOutside(MyComponent.this);
-        }
-
-        @Override
-        public Component getDefaultComponent(Container aContainer) {
-          return WeakFocusStackManager.getInstance().getLastFocusedOutside(MyComponent.this);
-        }
-      });
     }
 
     @NotNull


### PR DESCRIPTION
The panel of Balloon used to define a FocusTraversalPolicy which was
supposed to define a custom focus traversal policy, but it did not do
the job very well: the TAB key was prevented from moving the focus to
elements of the Balloon panel.

This patch makes the balloon panel a FocusCycleRoot which makes it more
comfortable to use the keyboard and removes the custom focus traversal
policy since it is not needed anymore.

Here is the link to [the issue](https://youtrack.jetbrains.com/issue/IDEA-232518)

@amaembo , we discussed it, please take a look if possible
@denis-fokin , I refactored a bit your changes from [your earlier commit](https://github.com/JetBrains/intellij-community/commit/5ad3469deb14835c061bc38cf69c6ccf7da190ea#diff-af8399b3067ea60af13798ec90ed5c6b), please take a look
 See PR 1298 in origin repo