### PR TITLE
Corrected code, when NIO methods silently failed for non-existing files

### DIFF
--- a/platform/bootstrap/src/com/intellij/ide/BootstrapClassLoaderUtil.java
+++ b/platform/bootstrap/src/com/intellij/ide/BootstrapClassLoaderUtil.java
@@ -13,6 +13,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
@@ -176,9 +177,11 @@ public final class BootstrapClassLoaderUtil {
 
   @NotNull
   private static List<String> loadJarOrder() {
-    try {
-      try (BufferedReader stream = new BufferedReader(new InputStreamReader(BootstrapClassLoaderUtil.class.getResourceAsStream(CLASSPATH_ORDER_FILE), StandardCharsets.UTF_8))) {
-        return FileUtilRt.loadLines(stream);
+    try (InputStream classpathOrderStream = BootstrapClassLoaderUtil.class.getResourceAsStream(CLASSPATH_ORDER_FILE)) {
+      if (classpathOrderStream != null) {
+        try (BufferedReader stream = new BufferedReader(new InputStreamReader(classpathOrderStream, StandardCharsets.UTF_8))) {
+          return FileUtilRt.loadLines(stream);
+        }
       }
     }
     catch (Exception ignored) {

--- a/platform/bootstrap/src/com/intellij/ide/startup/StartupActionScriptManager.java
+++ b/platform/bootstrap/src/com/intellij/ide/startup/StartupActionScriptManager.java
@@ -80,7 +80,7 @@ public class StartupActionScriptManager {
 
   @NotNull
   private static List<ActionCommand> loadActionScript(@NotNull Path scriptFile) throws IOException {
-    if (!Files.isRegularFile(scriptFile)) {
+    if (!scriptFile.toFile().exists() || !Files.isRegularFile(scriptFile)) {
       return new ArrayList<>();
     }
 
@@ -109,7 +109,7 @@ public class StartupActionScriptManager {
         oos.writeObject(commands.toArray(ActionCommand.EMPTY_ARRAY));
       }
     }
-    else if (Files.exists(scriptFile)) {
+    else if (scriptFile.toFile().exists()) {
       FileUtilRt.delete(scriptFile.toFile());
     }
   }

--- a/platform/platform-impl/src/com/intellij/idea/SplashManager.java
+++ b/platform/platform-impl/src/com/intellij/idea/SplashManager.java
@@ -79,6 +79,9 @@ public final class SplashManager {
   @Nullable
   private static IdeFrameImpl createFrameIfPossible() throws IOException {
     Path infoFile = Paths.get(PathManager.getSystemPath(), "lastProjectFrameInfo");
+    if (!infoFile.toFile().exists()) {
+      return null;
+    }
     ByteBuffer buffer;
     try (SeekableByteChannel channel = Files.newByteChannel(infoFile)) {
       buffer = ByteBuffer.allocate((int)channel.size());

--- a/platform/util-class-loader/src/com/intellij/util/lang/FileLoader.java
+++ b/platform/util-class-loader/src/com/intellij/util/lang/FileLoader.java
@@ -39,7 +39,7 @@ class FileLoader extends Loader {
     }
 
     boolean containsClasses = false;
-    
+
     for (File file : files) {
       final boolean isClass = file.getPath().endsWith(UrlClassLoader.CLASS_EXTENSION);
       if (isClass) {
@@ -72,20 +72,20 @@ class FileLoader extends Loader {
   private static class DirEntry {
     static final int[] empty = new int[0];
     volatile int[] childrenNameHashes;
-    
+
     volatile DirEntry[] childrenDirectories;
     final int nameHash;
     @NotNull
     final String name;
-    
+
     DirEntry(int nameHash, @NotNull String name) {
       this.nameHash = nameHash;
       this.name = name;
     }
   }
-  
+
   private final DirEntry root = new DirEntry(0, "");
-  
+
   @Override
   @Nullable
   Resource getResource(@NotNull final String name) {

--- a/platform/util/ui/src/com/intellij/util/SVGLoaderCache.java
+++ b/platform/util/ui/src/com/intellij/util/SVGLoaderCache.java
@@ -47,7 +47,7 @@ public abstract class SVGLoaderCache {
                                            double scale,
                                            @NotNull ImageLoader.Dimension2DDouble docSize) {
     Path file = cacheFile(theme, imageBytes, scale);
-    if (!Files.isRegularFile(file)) {
+    if (!file.toFile().exists() || !Files.isRegularFile(file)) {
       return null;
     }
 

--- a/platform/util/ui/src/com/intellij/util/SVGLoaderCacheIO.java
+++ b/platform/util/ui/src/com/intellij/util/SVGLoaderCacheIO.java
@@ -75,7 +75,9 @@ public class SVGLoaderCacheIO {
 
     buff.flip();
 
-    Files.createDirectories(file.getParent());
+    if (!file.getParent().toFile().exists()) {
+      Files.createDirectories(file.getParent());
+    }
 
     // we may have a race condition:
     // thread A - is writing the cache


### PR DESCRIPTION
Added additional checks to some classes/methods, where the file existance was checked with NIO to Path.toFile().exists().
This approach doesn't throw a silent exception and it is a little bit faster.
 See PR 1275 in origin repo