### PR TITLE
IDEA-217968: Force DirectoryBasedStorage VirtualFile to be a directory

### DIFF
--- a/platform/configuration-store-impl/src/DirectoryBasedStorage.kt
+++ b/platform/configuration-store-impl/src/DirectoryBasedStorage.kt
@@ -205,6 +205,8 @@ open class DirectoryBasedStorage(private val dir: Path,
 
         if (dir == null || !dir.exists()) {
           dir = storage.virtualFile
+          // The virtual file should be a directory, delete it otherwise so it will be properly re-created below.
+          dir?.takeUnless { it.isDirectory }?.delete(this)
           if (dir == null || !dir.exists()) {
             dir = createDir(storage.dir, this)
             storage.cachedVirtualFile = dir


### PR DESCRIPTION
That will prevent an IOException such as '[...].idea/codeStyles' is not
a directory in VFS.
 See PR 1270 in origin repo