### PR TITLE
fix NPE in MacIntelliJButtonUI::getDarculaButtonSize

### DIFF
--- a/platform/platform-impl/src/com/intellij/ide/ui/laf/darcula/ui/DarculaButtonUI.java
+++ b/platform/platform-impl/src/com/intellij/ide/ui/laf/darcula/ui/DarculaButtonUI.java
@@ -11,7 +11,6 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.ui.JBColor;
 import com.intellij.ui.components.JBOptionButton;
 import com.intellij.ui.scale.JBUIScale;
-import com.intellij.util.ObjectUtils;
 import com.intellij.util.ui.*;
 
 import javax.swing.*;
@@ -258,7 +257,7 @@ public class DarculaButtonUI extends BasicButtonUI {
     int textIconGap = StringUtil.isEmpty(b.getText()) || b.getIcon() == null ? 0 : b.getIconTextGap();
     Dimension size = BasicGraphicsUtils.getPreferredButtonSize(b, textIconGap);
     // "BasicGraphicsUtils.getPreferredButtonSize" can return null -> https://bugs.openjdk.java.net/browse/JDK-4694008
-    return getDarculaButtonSize(c, ObjectUtils.notNull(size, JBUI.emptySize()));
+    return getDarculaButtonSize(c, size == null ? new Dimension() : size);
   }
 
   @Override

--- a/platform/platform-impl/src/com/intellij/ide/ui/laf/darcula/ui/DarculaButtonUI.java
+++ b/platform/platform-impl/src/com/intellij/ide/ui/laf/darcula/ui/DarculaButtonUI.java
@@ -232,7 +232,6 @@ public class DarculaButtonUI extends BasicButtonUI {
 
   protected Dimension getDarculaButtonSize(JComponent c, Dimension prefSize) {
     Insets i = c.getInsets();
-    prefSize = ObjectUtils.notNull(prefSize, JBUI.emptySize());
 
     if (UIUtil.isHelpButton(c) || isSquare(c)) {
       int helpDiam = HELP_BUTTON_DIAMETER.get();
@@ -258,7 +257,8 @@ public class DarculaButtonUI extends BasicButtonUI {
     AbstractButton b = (AbstractButton)c;
     int textIconGap = StringUtil.isEmpty(b.getText()) || b.getIcon() == null ? 0 : b.getIconTextGap();
     Dimension size = BasicGraphicsUtils.getPreferredButtonSize(b, textIconGap);
-    return getDarculaButtonSize(c, size);
+    // "BasicGraphicsUtils.getPreferredButtonSize" can return null -> https://bugs.openjdk.java.net/browse/JDK-4694008
+    return getDarculaButtonSize(c, ObjectUtils.notNull(size, JBUI.emptySize()));
   }
 
   @Override

--- a/platform/platform-impl/src/com/intellij/ide/ui/laf/intellij/MacIntelliJButtonUI.java
+++ b/platform/platform-impl/src/com/intellij/ide/ui/laf/intellij/MacIntelliJButtonUI.java
@@ -3,6 +3,7 @@ package com.intellij.ide.ui.laf.intellij;
 
 import com.intellij.ide.ui.laf.darcula.ui.DarculaButtonUI;
 import com.intellij.ui.Gray;
+import com.intellij.util.ObjectUtils;
 import com.intellij.util.ui.*;
 
 import javax.swing.*;
@@ -118,6 +119,7 @@ public class MacIntelliJButtonUI extends DarculaButtonUI {
     }
     else {
       Insets i = c.getInsets();
+      prefSize = ObjectUtils.notNull(prefSize, JBUI.emptySize());
       return new Dimension(getComboAction(c) != null ?
                            prefSize.width :
                            Math.max(HORIZONTAL_PADDING.get() * 2 + prefSize.width, MINIMUM_BUTTON_WIDTH.get() + i.left + i.right),

--- a/platform/platform-impl/src/com/intellij/ide/ui/laf/intellij/MacIntelliJButtonUI.java
+++ b/platform/platform-impl/src/com/intellij/ide/ui/laf/intellij/MacIntelliJButtonUI.java
@@ -3,7 +3,6 @@ package com.intellij.ide.ui.laf.intellij;
 
 import com.intellij.ide.ui.laf.darcula.ui.DarculaButtonUI;
 import com.intellij.ui.Gray;
-import com.intellij.util.ObjectUtils;
 import com.intellij.util.ui.*;
 
 import javax.swing.*;
@@ -119,7 +118,6 @@ public class MacIntelliJButtonUI extends DarculaButtonUI {
     }
     else {
       Insets i = c.getInsets();
-      prefSize = ObjectUtils.notNull(prefSize, JBUI.emptySize());
       return new Dimension(getComboAction(c) != null ?
                            prefSize.width :
                            Math.max(HORIZONTAL_PADDING.get() * 2 + prefSize.width, MINIMUM_BUTTON_WIDTH.get() + i.left + i.right),


### PR DESCRIPTION

`MacIntelliJButtonUI` overwrites `getDarculaButtonSize` and doesn't handle the the case that the dimension returned by `BasicGraphicsUtils.getPreferredButtonSize` is null
when "myButton.getComponentCount() > 0". More about this undocumented behavior can be found here: https://bugs.openjdk.java.net/browse/JDK-4694008.

The same fix was added for `DarculaButtonUI::getDarculaButtonSize` (https://github.com/JetBrains/intellij-community/commit/9372853553274c3c2d9431382b66403c337d1faf).

I couldn't test this fix because I don't have a mac available.
I found one report about this NPE here: https://github.com/exbin/bined-intellij-plugin/issues/22
 See PR 1266 in origin repo