### PR TITLE
TypeMigrationStatementProcessor should process non array PsiNewExpression the same way it processes PsiMethodCallExpression

### DIFF
--- a/java/typeMigration/test/com/intellij/refactoring/TypeMigrationTest.java
+++ b/java/typeMigration/test/com/intellij/refactoring/TypeMigrationTest.java
@@ -880,6 +880,10 @@ public class TypeMigrationTest extends TypeMigrationTestBase {
     doTestFieldType("migrationField", myFactory.createTypeFromText("Test<Short>", null));
   }
 
+  public void testNonMigrableConstructorParameter(){
+    doTestFieldType("FIRST", PsiType.LONG);
+  }
+  
   private void doTestReturnType(final String methodName, final String migrationType) {
     start(new RulesProvider() {
       @Override

--- a/java/typeMigration/testData/refactoring/typeMigration/nonMigrableConstructorParameter/after/Test.items
+++ b/java/typeMigration/testData/refactoring/typeMigration/nonMigrableConstructorParameter/after/Test.items
@@ -1,0 +1,11 @@
+Types:
+PsiField:FIRST : long
+PsiParameter:number : long
+PsiReferenceExpression:FIRST : long
+
+Conversions:
+0 -> $
+FIRST -> $
+
+New expression type changes:
+Fails:

--- a/java/typeMigration/testData/refactoring/typeMigration/nonMigrableConstructorParameter/after/test.java
+++ b/java/typeMigration/testData/refactoring/typeMigration/nonMigrableConstructorParameter/after/test.java
@@ -1,0 +1,14 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+public class Test {
+    
+    private static final long FIRST = 0;
+    
+    private Test(long number){
+        
+    }
+    
+    public static Test create(){
+       return new Test(FIRST);
+    }
+
+}

--- a/java/typeMigration/testData/refactoring/typeMigration/nonMigrableConstructorParameter/before/test.java
+++ b/java/typeMigration/testData/refactoring/typeMigration/nonMigrableConstructorParameter/before/test.java
@@ -1,0 +1,14 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+public class Test {
+    
+    private static final int FIRST = 0;
+    
+    private Test(int number){
+        
+    }
+    
+    public static Test create(){
+       return new Test(FIRST);
+    }
+
+}


### PR DESCRIPTION
Let be:
```java
class Foo {
  Foo(int i){

  }
}

class Bar {

  public Foo foo(){
    int i = 0;
    return new Foo(i);
  }
}
```

When triggering TypeMigration on `int i = 0` to migrate `int` to `long`, it ends up with the following result:
```java
class Foo {
  Foo(int i){

  }
}

class Bar {

  public Foo foo(){
    long i = 0;
    return new Foo(i); // Compilation error, cannot convert long to int
  }
}
```

`new Foo(i);` does not compile anymore.

This PR fixes it by processing non  array PsiNewExpression the same way as PsiMethodCallExpression.
 See PR 1239 in origin repo