### PR TITLE
Implement serialization bindings for byte and char primitives

### DIFF
--- a/platform/object-serializer/src/primitiveBindings.kt
+++ b/platform/object-serializer/src/primitiveBindings.kt
@@ -27,13 +27,11 @@ internal fun registerPrimitiveBindings(classToRootBindingFactory: MutableMap<Cla
 
   classToNestedBindingFactory.put(java.lang.Boolean.TYPE, resolved(BooleanBinding()))
 
-  val char: NestedBindingFactory = { throw UnsupportedOperationException("char is not supported") }
-  classToNestedBindingFactory.put(Character.TYPE, char)
-  classToNestedBindingFactory.put(Character::class.java, char)
+  classToNestedBindingFactory.put(Character.TYPE, resolved(CharBinding()))
+  classToNestedBindingFactory.put(Character::class.java, resolved(CharBinding()))
 
-  val byte: NestedBindingFactory = { throw UnsupportedOperationException("byte is not supported") }
-  classToNestedBindingFactory.put(java.lang.Byte.TYPE, byte)
-  classToNestedBindingFactory.put(java.lang.Byte::class.java, byte)
+  classToNestedBindingFactory.put(java.lang.Byte.TYPE, resolved(ByteBinding()))
+  classToNestedBindingFactory.put(java.lang.Byte::class.java, resolved(ByteBinding()))
 }
 
 private class FloatAsObjectBinding : Binding {
@@ -103,6 +101,12 @@ private open class IntBinding : Binding {
 
   override fun deserialize(hostObject: Any, property: MutableAccessor, context: ReadContext) {
     property.setInt(hostObject, context.reader.intValue())
+  }
+}
+
+private class ByteBinding : IntBinding() {
+  override fun deserialize(hostObject: Any, property: MutableAccessor, context: ReadContext) {
+    property.setByte(hostObject, context.reader.intValue().toByte())
   }
 }
 
@@ -179,5 +183,19 @@ internal class StringBinding : Binding {
     else {
       context.writer.writeString(s)
     }
+  }
+}
+
+private class CharBinding : Binding {
+  override fun deserialize(context: ReadContext, hostObject: Any?): Any {
+    return context.reader.stringValue().first()
+  }
+
+  override fun serialize(obj: Any, context: WriteContext) {
+    context.writer.writeSymbol(obj.toString())
+  }
+
+  override fun deserialize(hostObject: Any, property: MutableAccessor, context: ReadContext) {
+    property.setChar(hostObject, context.reader.stringValue().first())
   }
 }

--- a/platform/object-serializer/testSrc/ObjectSerializerTest.kt
+++ b/platform/object-serializer/testSrc/ObjectSerializerTest.kt
@@ -34,6 +34,11 @@ class ObjectSerializerTest {
   }
 
   @Test
+  fun primitives(){
+    test(TestPrimitivesBean())
+  }
+
+  @Test
   fun `int and null string`() {
     test(TestBean())
   }
@@ -252,4 +257,23 @@ private class TestFloatBean {
 private class TestGenericBean<T> {
   @JvmField
   var data: TestGenericBean<T>? = null
+}
+
+private class TestPrimitivesBean {
+  @JvmField
+  val byte: Byte = 1
+  @JvmField
+  val short: Short = 1
+  @JvmField
+  val int: Int = 1
+  @JvmField
+  val long: Long = 1L
+  @JvmField
+  val float: Float = 1.0f
+  @JvmField
+  val double: Double = 1.0
+  @JvmField
+  val boolean: Boolean = true
+  @JvmField
+  val char: Char = 'ǵ'
 }

--- a/platform/util/src/com/intellij/serialization/FieldAccessor.java
+++ b/platform/util/src/com/intellij/serialization/FieldAccessor.java
@@ -68,6 +68,16 @@ final class FieldAccessor implements MutableAccessor {
   }
 
   @Override
+  public void setChar(@NotNull Object host, char value) {
+    try {
+      myField.setChar(host, value);
+    }
+    catch (IllegalAccessException e) {
+      throw new SerializationException("Writing " + myField, e);
+    }
+  }
+
+  @Override
   public void setBoolean(@NotNull Object host, boolean value) {
     try {
       myField.setBoolean(host, value);
@@ -81,6 +91,16 @@ final class FieldAccessor implements MutableAccessor {
   public void setInt(@NotNull Object host, int value) {
     try {
       myField.setInt(host, value);
+    }
+    catch (IllegalAccessException e) {
+      throw new SerializationException("Writing " + myField, e);
+    }
+  }
+
+  @Override
+  public void setByte(@NotNull Object host, byte value) {
+    try {
+      myField.setByte(host, value);
     }
     catch (IllegalAccessException e) {
       throw new SerializationException("Writing " + myField, e);

--- a/platform/util/src/com/intellij/serialization/MutableAccessor.java
+++ b/platform/util/src/com/intellij/serialization/MutableAccessor.java
@@ -10,10 +10,14 @@ import org.jetbrains.annotations.Nullable;
 public interface MutableAccessor extends Accessor {
   void set(@NotNull Object host, @Nullable Object value);
 
+  void setChar(@NotNull Object host, char value);
+
   void setBoolean(@NotNull Object host, boolean value);
 
   void setInt(@NotNull Object host, int value);
 
+  void setByte(@NotNull Object host, byte value);
+  
   void setShort(@NotNull Object host, short value);
 
   void setLong(@NotNull Object host, long value);

--- a/platform/util/src/com/intellij/serialization/PropertyAccessor.java
+++ b/platform/util/src/com/intellij/serialization/PropertyAccessor.java
@@ -119,12 +119,22 @@ public final class PropertyAccessor implements MutableAccessor {
   }
 
   @Override
+  public void setChar(@NotNull Object host, char value) {
+    set(host, value);
+  }
+
+  @Override
   public void setBoolean(@NotNull Object host, boolean value) {
     set(host, value);
   }
 
   @Override
   public void setInt(@NotNull Object host, int value) {
+    set(host, value);
+  }
+
+  @Override
+  public void setByte(@NotNull Object host, byte value) {
     set(host, value);
   }
 


### PR DESCRIPTION
Currently, neither `byte` nor `char` primitives can be serialized.
This adds the missing bindings for those types.
 See PR 1238 in origin repo