### PR TITLE
Allow TypeMigrationProcessor to stop on first failed conversion

### DIFF
--- a/java/java-impl/src/com/intellij/refactoring/typeMigration/TypeMigrationProcessor.java
+++ b/java/java-impl/src/com/intellij/refactoring/typeMigration/TypeMigrationProcessor.java
@@ -43,6 +43,7 @@ public class TypeMigrationProcessor extends BaseRefactoringProcessor {
   private final Function<PsiElement, PsiType> myRootTypes;
   private final boolean myAllowDependentRoots;
   private final TypeMigrationRules myRules;
+  private final boolean myStopOnFirstFailedConversion;
   private TypeMigrationLabeler myLabeler;
 
   public TypeMigrationProcessor(final Project project,
@@ -50,11 +51,21 @@ public class TypeMigrationProcessor extends BaseRefactoringProcessor {
                                 final Function<PsiElement, PsiType> rootTypes,
                                 final TypeMigrationRules rules,
                                 final boolean allowDependentRoots) {
+    this(project, roots, rootTypes, rules, allowDependentRoots, false);
+  }
+
+  public TypeMigrationProcessor(final Project project,
+                                final PsiElement[] roots,
+                                final Function<PsiElement, PsiType> rootTypes,
+                                final TypeMigrationRules rules,
+                                final boolean allowDependentRoots,
+                                final boolean stopOnFirstFailedConversion) {
     super(project);
     myRoots = roots;
     myRules = rules;
     myRootTypes = rootTypes;
     myAllowDependentRoots = allowDependentRoots;
+    myStopOnFirstFailedConversion = stopOnFirstFailedConversion;
   }
 
   public static void runHighlightingTypeMigration(final Project project,
@@ -212,7 +223,8 @@ public class TypeMigrationProcessor extends BaseRefactoringProcessor {
   @NotNull
   @Override
   public UsageInfo[] findUsages() {
-    myLabeler = new TypeMigrationLabeler(myRules, myRootTypes, myAllowDependentRoots ? null : myRoots, myProject);
+    myLabeler =
+      new TypeMigrationLabeler(myRules, myRootTypes, myAllowDependentRoots ? null : myRoots, myProject, myStopOnFirstFailedConversion);
 
     try {
       return myLabeler.getMigratedUsages(!isPreviewUsages(), myRoots);

--- a/java/typeMigration/test/com/intellij/refactoring/AllTypeMigrationTestSuite.java
+++ b/java/typeMigration/test/com/intellij/refactoring/AllTypeMigrationTestSuite.java
@@ -13,6 +13,7 @@ import org.junit.runners.Suite;
   TypeMigrationByAtomicRuleTest.class,
   TypeMigrationByThreadLocalRuleTest.class,
   TypeMigrationByLongAdderTest.class,
+  TypeMigrationStopOnFirstFailedConversionTest.class,
   MigrateTypeSignatureTest.class,
   ChangeTypeSignatureTest.class,
   WildcardTypeMigrationTest.class,

--- a/java/typeMigration/test/com/intellij/refactoring/TypeMigrationStopOnFirstFailedConversionTest.java
+++ b/java/typeMigration/test/com/intellij/refactoring/TypeMigrationStopOnFirstFailedConversionTest.java
@@ -1,0 +1,32 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.intellij.refactoring;
+
+import com.intellij.openapi.roots.LanguageLevelProjectExtension;
+import com.intellij.pom.java.LanguageLevel;
+import com.intellij.psi.PsiType;
+
+/**
+ * @author Réda Housni Alaoui
+ */
+public class TypeMigrationStopOnFirstFailedConversionTest extends TypeMigrationTestBase {
+
+  @Override
+  protected String getTestDataPath() {
+    return super.getTestDataPath() + "/refactoring/typeMigrationStopOnFirstFailedConversion/";
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    LanguageLevelProjectExtension.getInstance(getProject()).setLanguageLevel(LanguageLevel.HIGHEST);
+  }
+
+  @Override
+  protected boolean stopOnFirstFailedConversion() {
+    return true;
+  }
+
+  public void testTwoFailedConversions() {
+    doTestFirstParamType("foo", PsiType.DOUBLE);
+  }
+}

--- a/java/typeMigration/test/com/intellij/refactoring/TypeMigrationTestBase.java
+++ b/java/typeMigration/test/com/intellij/refactoring/TypeMigrationTestBase.java
@@ -138,13 +138,17 @@ public abstract class TypeMigrationTestBase extends LightMultiFileTestCase {
     doTest(() -> this.performAction(className, provider));
   }
 
+  protected boolean stopOnFirstFailedConversion(){
+    return false;
+  }
+  
   private void performAction(String className, RulesProvider provider) throws Exception {
     PsiClass aClass = myFixture.findClass(className);
     final PsiElement[] migrationElements = provider.victims(aClass);
     final PsiType migrationType = provider.migrationType(migrationElements[0]);
     final TypeMigrationRules rules = new TypeMigrationRules(getProject());
     rules.setBoundScope(new LocalSearchScope(aClass.getContainingFile()));
-    final TestTypeMigrationProcessor pr = new TestTypeMigrationProcessor(getProject(), migrationElements, migrationType, rules);
+    final TestTypeMigrationProcessor pr = new TestTypeMigrationProcessor(getProject(), migrationElements, migrationType, rules, stopOnFirstFailedConversion());
 
     final UsageInfo[] usages = pr.findUsages();
     final String report = pr.getLabeler().getMigrationReport();
@@ -170,8 +174,8 @@ public abstract class TypeMigrationTestBase extends LightMultiFileTestCase {
   }
 
   private static class TestTypeMigrationProcessor extends TypeMigrationProcessor {
-    TestTypeMigrationProcessor(final Project project, final PsiElement[] roots, final PsiType migrationType, final TypeMigrationRules rules) {
-      super(project, roots, Functions.constant(migrationType), rules, true);
+    TestTypeMigrationProcessor(final Project project, final PsiElement[] roots, final PsiType migrationType, final TypeMigrationRules rules, final boolean stopOnFirstFailedConversion) {
+      super(project, roots, Functions.constant(migrationType), rules, true, stopOnFirstFailedConversion);
     }
   }
 

--- a/java/typeMigration/testData/refactoring/typeMigrationStopOnFirstFailedConversion/twoFailedConversions/after/Test.items
+++ b/java/typeMigration/testData/refactoring/typeMigrationStopOnFirstFailedConversion/twoFailedConversions/after/Test.items
@@ -1,0 +1,8 @@
+Types:
+PsiParameter:i : double
+
+Conversions:
+
+New expression type changes:
+Fails:
+i->double

--- a/java/typeMigration/testData/refactoring/typeMigrationStopOnFirstFailedConversion/twoFailedConversions/after/test.java
+++ b/java/typeMigration/testData/refactoring/typeMigrationStopOnFirstFailedConversion/twoFailedConversions/after/test.java
@@ -1,0 +1,6 @@
+class Test {
+   void foo(double i) {
+        int[] a = new int[i];
+        System.out.println(a[i]);
+   }
+}

--- a/java/typeMigration/testData/refactoring/typeMigrationStopOnFirstFailedConversion/twoFailedConversions/before/test.java
+++ b/java/typeMigration/testData/refactoring/typeMigrationStopOnFirstFailedConversion/twoFailedConversions/before/test.java
@@ -1,0 +1,6 @@
+class Test {
+   void foo(int i) {
+        int[] a = new int[i];
+        System.out.println(a[i]);
+   }
+}


### PR DESCRIPTION
For performance reason, this PR allows to let the TypeMigrationProcessor stop on the first failed conversion.
 See PR 1237 in origin repo