### PR TITLE
Let TypeMigrationProcessor handle primitive/non-primitive conversion

### DIFF
--- a/java/java-impl/src/com/intellij/refactoring/typeMigration/TypeMigrationProcessor.java
+++ b/java/java-impl/src/com/intellij/refactoring/typeMigration/TypeMigrationProcessor.java
@@ -42,6 +42,7 @@ public class TypeMigrationProcessor extends BaseRefactoringProcessor {
   private PsiElement[] myRoots;
   private final Function<PsiElement, PsiType> myRootTypes;
   private final boolean myAllowDependentRoots;
+  private final boolean myAutoBox;
   private final TypeMigrationRules myRules;
   private TypeMigrationLabeler myLabeler;
 
@@ -50,11 +51,21 @@ public class TypeMigrationProcessor extends BaseRefactoringProcessor {
                                 final Function<PsiElement, PsiType> rootTypes,
                                 final TypeMigrationRules rules,
                                 final boolean allowDependentRoots) {
+    this(project, roots, rootTypes, rules, allowDependentRoots, false);
+  }
+
+  public TypeMigrationProcessor(final Project project,
+                                final PsiElement[] roots,
+                                final Function<PsiElement, PsiType> rootTypes,
+                                final TypeMigrationRules rules,
+                                final boolean allowDependentRoots,
+                                final boolean autoBox) {
     super(project);
     myRoots = roots;
     myRules = rules;
     myRootTypes = rootTypes;
     myAllowDependentRoots = allowDependentRoots;
+    myAutoBox = autoBox;
   }
 
   public static void runHighlightingTypeMigration(final Project project,
@@ -212,7 +223,7 @@ public class TypeMigrationProcessor extends BaseRefactoringProcessor {
   @NotNull
   @Override
   public UsageInfo[] findUsages() {
-    myLabeler = new TypeMigrationLabeler(myRules, myRootTypes, myAllowDependentRoots ? null : myRoots, myProject);
+    myLabeler = new TypeMigrationLabeler(myRules, myRootTypes, myAllowDependentRoots ? null : myRoots, myProject, myAutoBox);
 
     try {
       return myLabeler.getMigratedUsages(!isPreviewUsages(), myRoots);

--- a/java/typeMigration/test/com/intellij/refactoring/AllTypeMigrationTestSuite.java
+++ b/java/typeMigration/test/com/intellij/refactoring/AllTypeMigrationTestSuite.java
@@ -13,6 +13,7 @@ import org.junit.runners.Suite;
   TypeMigrationByAtomicRuleTest.class,
   TypeMigrationByThreadLocalRuleTest.class,
   TypeMigrationByLongAdderTest.class,
+  TypeMigrationAutoboxingTest.class,
   MigrateTypeSignatureTest.class,
   ChangeTypeSignatureTest.class,
   WildcardTypeMigrationTest.class,

--- a/java/typeMigration/test/com/intellij/refactoring/TypeMigrationAutoboxingTest.java
+++ b/java/typeMigration/test/com/intellij/refactoring/TypeMigrationAutoboxingTest.java
@@ -1,0 +1,42 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.intellij.refactoring;
+
+import com.intellij.openapi.roots.LanguageLevelProjectExtension;
+import com.intellij.pom.java.LanguageLevel;
+import com.intellij.psi.PsiElementFactory;
+
+/**
+ * @author Réda Housni Alaoui
+ */
+public class TypeMigrationAutoboxingTest extends TypeMigrationTestBase {
+
+  private PsiElementFactory myFactory;
+
+  @Override
+  protected String getTestDataPath() {
+    return super.getTestDataPath() + "/refactoring/typeMigrationAutoboxing/";
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    LanguageLevelProjectExtension.getInstance(getProject()).setLanguageLevel(LanguageLevel.HIGHEST);
+    myFactory = getElementFactory();
+  }
+
+  @Override
+  public void tearDown() throws Exception {
+    myFactory = null;
+
+    super.tearDown();
+  }
+
+  @Override
+  protected boolean autoBox() {
+    return true;
+  }
+
+  public void testIntToLong() {
+    doTestMethodType("bar", myFactory.createTypeByFQClassName(Long.class.getCanonicalName()));
+  }
+}

--- a/java/typeMigration/test/com/intellij/refactoring/TypeMigrationTestBase.java
+++ b/java/typeMigration/test/com/intellij/refactoring/TypeMigrationTestBase.java
@@ -137,6 +137,10 @@ public abstract class TypeMigrationTestBase extends LightMultiFileTestCase {
   public void start(final RulesProvider provider, final String className) {
     doTest(() -> this.performAction(className, provider));
   }
+  
+  protected boolean autoBox(){
+    return false;
+  }
 
   private void performAction(String className, RulesProvider provider) throws Exception {
     PsiClass aClass = myFixture.findClass(className);
@@ -144,7 +148,7 @@ public abstract class TypeMigrationTestBase extends LightMultiFileTestCase {
     final PsiType migrationType = provider.migrationType(migrationElements[0]);
     final TypeMigrationRules rules = new TypeMigrationRules(getProject());
     rules.setBoundScope(new LocalSearchScope(aClass.getContainingFile()));
-    final TestTypeMigrationProcessor pr = new TestTypeMigrationProcessor(getProject(), migrationElements, migrationType, rules);
+    final TestTypeMigrationProcessor pr = new TestTypeMigrationProcessor(getProject(), migrationElements, migrationType, rules, autoBox());
 
     final UsageInfo[] usages = pr.findUsages();
     final String report = pr.getLabeler().getMigrationReport();
@@ -170,8 +174,8 @@ public abstract class TypeMigrationTestBase extends LightMultiFileTestCase {
   }
 
   private static class TestTypeMigrationProcessor extends TypeMigrationProcessor {
-    TestTypeMigrationProcessor(final Project project, final PsiElement[] roots, final PsiType migrationType, final TypeMigrationRules rules) {
-      super(project, roots, Functions.constant(migrationType), rules, true);
+    TestTypeMigrationProcessor(final Project project, final PsiElement[] roots, final PsiType migrationType, final TypeMigrationRules rules, final boolean autoBox) {
+      super(project, roots, Functions.constant(migrationType), rules, true, autoBox);
     }
   }
 

--- a/java/typeMigration/testData/refactoring/typeMigrationAutoboxing/intToLong/after/Test.items
+++ b/java/typeMigration/testData/refactoring/typeMigrationAutoboxing/intToLong/after/Test.items
@@ -1,0 +1,11 @@
+Types:
+PsiMethod:bar : long
+PsiMethod:foo : java.lang.Long
+PsiMethodCallExpression:bar() : long
+
+Conversions:
+0 -> $
+bar() -> $
+
+New expression type changes:
+Fails:

--- a/java/typeMigration/testData/refactoring/typeMigrationAutoboxing/intToLong/after/test.java
+++ b/java/typeMigration/testData/refactoring/typeMigrationAutoboxing/intToLong/after/test.java
@@ -1,0 +1,10 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+class Test {
+  public Long foo() {
+    return bar();
+  }
+
+  public long bar() {
+    return 0;
+  }
+}

--- a/java/typeMigration/testData/refactoring/typeMigrationAutoboxing/intToLong/before/test.java
+++ b/java/typeMigration/testData/refactoring/typeMigrationAutoboxing/intToLong/before/test.java
@@ -1,0 +1,10 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+class Test {
+  public Integer foo() {
+    return bar();
+  }
+
+  public int bar() {
+    return 0;
+  }
+}


### PR DESCRIPTION
Let be:
```java
public Integer foo() {
  return bar();
}

public int bar() {
  return 0;
}
```

When I ask TypeMigrationProcessor to migrate method `bar` return type from int to long, I end up with:
```java
public long foo() {
  return bar();
}

public long bar() {
  return 0;
}
```

`foo` return type is migrated from `Integer` to `long`. This is incorrect and will cause issues among which null pointer exceptions.

The current PR let TypeMigrationProcessor maintain the primitive/non-primitive aspect of type during the migration. e.g. Integer -> long migration will be turned to Integer -> Long before executing it. Although I think it should be the default behaviour, the new behaviour is introduced as an opt-in.
 See PR 1235 in origin repo