### PR TITLE
Through TypeMigrationProcessor, allow to disable TypeMigrationLabeler warning

### DIFF
--- a/java/java-impl/src/com/intellij/refactoring/typeMigration/TypeMigrationLabeler.java
+++ b/java/java-impl/src/com/intellij/refactoring/typeMigration/TypeMigrationLabeler.java
@@ -418,8 +418,12 @@ public class TypeMigrationLabeler {
   }
 
   public TypeMigrationUsageInfo[] getMigratedUsages(boolean autoMigrate, final PsiElement... roots) {
+    return getMigratedUsages(autoMigrate, autoMigrate, roots);
+  }
+
+  public TypeMigrationUsageInfo[] getMigratedUsages(boolean autoMigrate, boolean showWarning, final PsiElement... roots) {
     if (myMigratedUsages == null) {
-      myShowWarning = autoMigrate;
+      myShowWarning = showWarning;
       migrate(autoMigrate, roots);
       myMigratedUsages = getMigratedUsages();
     }

--- a/java/java-impl/src/com/intellij/refactoring/typeMigration/TypeMigrationProcessor.java
+++ b/java/java-impl/src/com/intellij/refactoring/typeMigration/TypeMigrationProcessor.java
@@ -43,6 +43,7 @@ public class TypeMigrationProcessor extends BaseRefactoringProcessor {
   private final Function<PsiElement, PsiType> myRootTypes;
   private final boolean myAllowDependentRoots;
   private final TypeMigrationRules myRules;
+  private final boolean myIsShowWarning;
   private TypeMigrationLabeler myLabeler;
 
   public TypeMigrationProcessor(final Project project,
@@ -50,11 +51,21 @@ public class TypeMigrationProcessor extends BaseRefactoringProcessor {
                                 final Function<PsiElement, PsiType> rootTypes,
                                 final TypeMigrationRules rules,
                                 final boolean allowDependentRoots) {
+    this(project, roots, rootTypes, rules, allowDependentRoots, true);
+  }
+
+  public TypeMigrationProcessor(final Project project,
+                                final PsiElement[] roots,
+                                final Function<PsiElement, PsiType> rootTypes,
+                                final TypeMigrationRules rules,
+                                final boolean allowDependentRoots,
+                                final boolean showWarning) {
     super(project);
     myRoots = roots;
     myRules = rules;
     myRootTypes = rootTypes;
     myAllowDependentRoots = allowDependentRoots;
+    myIsShowWarning = showWarning;
   }
 
   public static void runHighlightingTypeMigration(final Project project,
@@ -215,7 +226,7 @@ public class TypeMigrationProcessor extends BaseRefactoringProcessor {
     myLabeler = new TypeMigrationLabeler(myRules, myRootTypes, myAllowDependentRoots ? null : myRoots, myProject);
 
     try {
-      return myLabeler.getMigratedUsages(!isPreviewUsages(), myRoots);
+      return myLabeler.getMigratedUsages(!isPreviewUsages(), !isPreviewUsages() && myIsShowWarning, myRoots);
     }
     catch (TypeMigrationLabeler.MigrateException e) {
       setPreviewUsages(true);
@@ -223,7 +234,7 @@ public class TypeMigrationProcessor extends BaseRefactoringProcessor {
       return myLabeler.getMigratedUsages(false, myRoots);
     }
   }
-
+  
   @Override
   protected void refreshElements(@NotNull PsiElement[] elements) {
     myRoots = elements;


### PR DESCRIPTION
I am building a massive refactoring process making use of TypeMigrationProcessor.
Each time the number of roots exceeds 10, IntelliJ displays a warning that I must acknowledge.

This PR allows to disable this warning.
 See PR 1232 in origin repo