### PR TITLE
Should the frame balloon be horizontally centered?

### DIFF
--- a/platform/platform-api/src/com/intellij/openapi/ui/popup/util/PopupUtil.java
+++ b/platform/platform-api/src/com/intellij/openapi/ui/popup/util/PopupUtil.java
@@ -185,7 +185,7 @@ public class PopupUtil {
       position = Balloon.Position.above;
     }
     else {
-      x = Math.min(10, size.width / 2);
+      x = Math.max(10, size.width / 2);
       y = size.height;
       position = Balloon.Position.below;
     }


### PR DESCRIPTION
Should the frame balloon be horizontally centered?

code: `PopupUtil.showBalloonForActiveFrame("Message...", MessageType.INFO)`

![img](https://user-images.githubusercontent.com/10737066/63576902-c5d4e500-c5bf-11e9-8d55-35fd7eedf9a1.png)

 See PR 1191 in origin repo