### PR TITLE
Improve support for gmavenplus-plugin

### DIFF
--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/plugins/groovy/MavenGroovyLanguageProvider.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/plugins/groovy/MavenGroovyLanguageProvider.java
@@ -32,6 +32,7 @@ public class MavenGroovyLanguageProvider extends MavenParamLanguageProvider {
   @Override
   public Language getLanguage(@NotNull XmlText xmlText, @NotNull MavenDomConfiguration configuration) {
     // Parameter 'source' of gmaven-plugin can be a peace of groovy code or file path or URL.
+    // Same applies to 'scripts.script' parameter of gmavenplus-plugin.
 
     String text = xmlText.getText();
 

--- a/plugins/maven/src/main/resources/META-INF/groovy-support.xml
+++ b/plugins/maven/src/main/resources/META-INF/groovy-support.xml
@@ -17,6 +17,10 @@
     <pluginDescriptor mavenId="org.codehaus.gmaven:groovy-maven-plugin">
       <param name="source" languageProvider="org.jetbrains.idea.maven.plugins.groovy.MavenGroovyLanguageProvider"/>
     </pluginDescriptor>
+
+    <pluginDescriptor mavenId="org.codehaus.gmavenplus:gmavenplus-plugin">
+      <param name="scripts/script" languageProvider="org.jetbrains.idea.maven.plugins.groovy.MavenGroovyLanguageProvider"/>
+    </pluginDescriptor>
   </extensions>
 
   <extensions defaultExtensionNs="org.intellij.groovy">

--- a/plugins/maven/src/test/java/org/jetbrains/idea/maven/plugins/groovy/MavenGroovyInjectionTest.groovy
+++ b/plugins/maven/src/test/java/org/jetbrains/idea/maven/plugins/groovy/MavenGroovyInjectionTest.groovy
@@ -77,6 +77,55 @@ class MavenGroovyInjectionTest extends LightJavaCodeInsightFixtureTestCase {
     assert lookups.containsAll(["String", "StringBuffer", "StringBuilder"])
   }
 
+  void testCompletionWithGmavenPlusPlugin() {
+    myFixture.configureByText("pom.xml", """
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>simpleMaven</groupId>
+  <artifactId>simpleMaven</artifactId>
+  <version>1.0</version>
+
+  <packaging>jar</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+        <version>1.0</version>
+        <executions>
+          <execution>
+            <id>gmavenplus-plugin-execution</id>
+            <phase>package</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+            <configuration>
+              <scripts>
+                <script>
+                  Collect<caret>
+                </script>
+              </scripts>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>
+""")
+
+    myFixture.completeBasic()
+
+    def lookups = myFixture.lookupElementStrings
+    assert lookups.containsAll(["Collection", "Collections", "AbstractCollection"])
+  }
+
   void testCompletion2() {
     myFixture.configureByText("pom.xml", """
 <?xml version="1.0" encoding="UTF-8"?>
@@ -192,6 +241,55 @@ class MavenGroovyInjectionTest extends LightJavaCodeInsightFixtureTestCase {
 
     assert element instanceof GrVariable
     assert element.getDeclaredType().getPresentableText() == "MavenProject"
+  }
+
+  void testInjectionVariablesWithGmavenPlusPlugin() {
+    myFixture.configureByText("pom.xml", """
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>simpleMaven</groupId>
+  <artifactId>simpleMaven</artifactId>
+  <version>1.0</version>
+
+  <packaging>jar</packaging>
+
+  <build>
+    <plugins>
+            <plugin>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <version>1.0</version>
+                <executions>
+                  <execution>
+                    <id>gmavenplus-plugin-execution</id>
+                    <phase>package</phase>
+                    <goals>
+                      <goal>execute</goal>
+                    </goals>
+                    <configuration>
+                      <scripts>
+                        <script>
+                          println session<caret>
+                        </script>
+                      </scripts>
+                    </configuration>
+                  </execution>
+                </executions>
+            </plugin>
+    </plugins>
+  </build>
+
+</project>
+""")
+
+    def element = myFixture.getElementAtCaret()
+
+    assert element instanceof GrVariable
+    assert element.getDeclaredType().getPresentableText() == "MavenSession"
   }
 
   void testHighlighting() {


### PR DESCRIPTION
This pull requests improves existing GMavenPlus support by injecting Groovy language for parameter `scripts > script` of GMavenPlus plugin.
([documentation](https://groovy.github.io/GMavenPlus/execute-mojo.html#scripts) says this parameter can contain inline Groovy scripts)

-----
*[GMavenPlus](https://github.com/groovy/GMavenPlus) is a rewrite of GMaven, a Maven plugin that allows to integrate Groovy into Maven projects. GMavenPlus has features that GMaven does not have (e.g. it supports latest Groovy versions) and is actively maintained.
So it makes sense to provide same quality IDE support for GMavenPlus as is provided for GMaven.*


 See PR 1169 in origin repo