### PR TITLE
Skip Kotlin classes in NotNullInstrumentingBuilder

### DIFF
--- a/jps/jps-builders/src/org/jetbrains/jps/incremental/instrumentation/BaseInstrumentingBuilder.java
+++ b/jps/jps-builders/src/org/jetbrains/jps/incremental/instrumentation/BaseInstrumentingBuilder.java
@@ -38,7 +38,7 @@ public abstract class BaseInstrumentingBuilder extends ClassProcessingBuilder {
       final BinaryContent originalContent = compiledClass.getContent();
       final ClassReader reader = new FailSafeClassReader(originalContent.getBuffer(), originalContent.getOffset(), originalContent.getLength());
       final int version = InstrumenterClassWriter.getClassFileVersion(reader);
-      if (IS_INSTRUMENTED_KEY.get(compiledClass, Boolean.FALSE) || !canInstrument(compiledClass, version)) {
+      if (IS_INSTRUMENTED_KEY.get(compiledClass, Boolean.FALSE) || !canInstrument(compiledClass, reader, version)) {
         // do not instrument the same content twice
         continue;
       }
@@ -72,7 +72,7 @@ public abstract class BaseInstrumentingBuilder extends ClassProcessingBuilder {
     return exitCode;
   }
 
-  protected abstract boolean canInstrument(CompiledClass compiledClass, int classFileVersion);
+  protected abstract boolean canInstrument(CompiledClass compiledClass, ClassReader reader, int classFileVersion);
 
   @Nullable
   protected abstract BinaryContent instrument(CompileContext context,

--- a/plugins/IntelliLang/intellilang-jps-plugin/src/org/jetbrains/jps/intellilang/instrumentation/PatternValidatorBuilder.java
+++ b/plugins/IntelliLang/intellilang-jps-plugin/src/org/jetbrains/jps/intellilang/instrumentation/PatternValidatorBuilder.java
@@ -37,7 +37,7 @@ public class PatternValidatorBuilder extends BaseInstrumentingBuilder {
   }
 
   @Override
-  protected boolean canInstrument(CompiledClass compiledClass, int classFileVersion) {
+  protected boolean canInstrument(CompiledClass compiledClass, ClassReader reader, int classFileVersion) {
     return !"module-info".equals(compiledClass.getClassName());
   }
 


### PR DESCRIPTION
Kotlin classes already contain null checks for parameters, so they should not be added by Intellij nullability instrumenter (see KT-13563 & KT-31879).

Instrumentation support was added in 1.3.40-eap-95, but it was disabled by default.
To enable it, check `kotlin.jps.instrument.bytecode` in registry and rebuild.

 See PR 1155 in origin repo