### PR TITLE
IDEA-212508: Reduce memory footprint of MultipleBuildsView.myBuildsMap

### DIFF
--- a/platform/lang-api/src/com/intellij/build/events/BuildEvent.java
+++ b/platform/lang-api/src/com/intellij/build/events/BuildEvent.java
@@ -60,4 +60,9 @@ public interface BuildEvent {
 
   @Nullable
   String getDescription();
+
+  /**
+   * Returns true if the event may have child events, i.e. events with the parent ID equal to the ID of this event.
+   */
+  boolean mayHaveChildren();
 }

--- a/platform/lang-impl/src/com/intellij/build/events/impl/AbstractBuildEvent.java
+++ b/platform/lang-impl/src/com/intellij/build/events/impl/AbstractBuildEvent.java
@@ -27,6 +27,8 @@ public abstract class AbstractBuildEvent implements BuildEvent {
     myParentId = parentId;
     myEventTime = eventTime;
     myMessage = message;
+    // java.lang.Object is never used as parentId. See the mayHaveChildren method.
+    assert parentId == null || !myParentId.getClass().equals(Object.class);
   }
 
   @NotNull
@@ -70,6 +72,11 @@ public abstract class AbstractBuildEvent implements BuildEvent {
 
   public void setDescription(@Nullable String description) {
     myDescription = description;
+  }
+
+  @Override
+  public boolean mayHaveChildren() {
+    return !myEventId.getClass().equals(Object.class);
   }
 
   @Override


### PR DESCRIPTION
The change is based on the observation that build events with java.lang.Object IDs never have child events.
 See PR 1136 in origin repo