### PR TITLE
IDEA-212454 Find usages does not detect generated accessors 

### DIFF
--- a/java/java-impl/src/com/intellij/find/findUsages/JavaFindUsagesHandler.java
+++ b/java/java-impl/src/com/intellij/find/findUsages/JavaFindUsagesHandler.java
@@ -167,6 +167,11 @@ public class JavaFindUsagesHandler extends FindUsagesHandler{
                                                                        ContainerUtil.iterate(containingClass.getMethods()));
         if (setter != null) accessors.add(setter);
         accessors.addAll(PropertyUtilBase.getAccessors(containingClass, fieldName));
+        if (!fieldName.equals(propertyName)) {
+          // getAccessors does not take code style into account. Search again using propertyName
+          // which does not contain field prefix/suffix
+          accessors.addAll(PropertyUtilBase.getAccessors(containingClass, propertyName));
+        }
         accessors.removeIf(accessor -> field != PropertyUtilBase.findPropertyFieldByMember(accessor));
         if (!accessors.isEmpty()) {
           boolean containsPhysical = ContainerUtil.find(accessors, psiMethod -> psiMethod.isPhysical()) != null;

--- a/java/java-psi-api/src/com/intellij/psi/util/PropertyUtilBase.java
+++ b/java/java-psi-api/src/com/intellij/psi/util/PropertyUtilBase.java
@@ -74,13 +74,15 @@ public class PropertyUtilBase {
 
   @NotNull
   public static List<PsiMethod> getSetters(@NotNull final PsiClass psiClass, final String propertyName) {
-    final String setterName = suggestSetterName(propertyName);
-    final PsiMethod[] psiMethods = psiClass.findMethodsByName(setterName, true);
-    final ArrayList<PsiMethod> list = new ArrayList<>(psiMethods.length);
-    for (PsiMethod method : psiMethods) {
-      if (filterMethods(method)) continue;
-      if (isSimplePropertySetter(method)) {
-        list.add(method);
+    final String[] names = suggestSetterNames(propertyName);
+    final ArrayList<PsiMethod> list = new ArrayList<>();
+    for (String name : names) {
+      final PsiMethod[] psiMethods = psiClass.findMethodsByName(name, true);
+      for (PsiMethod method : psiMethods) {
+        if (filterMethods(method)) continue;
+        if (isSimplePropertySetter(method)) {
+          list.add(method);
+        }
       }
     }
     return list;
@@ -399,7 +401,11 @@ public class PropertyUtilBase {
   @NonNls
   @NotNull
   public static String[] suggestGetterNames(@NotNull String propertyName) {
-    final String str = StringUtil.capitalizeWithJavaBeanConvention(StringUtil.sanitizeJavaIdentifier(propertyName));
+    String sanitized = StringUtil.sanitizeJavaIdentifier(propertyName);
+    final String str = StringUtil.capitalizeWithJavaBeanConvention(sanitized);
+    if (checkPrefix(sanitized, "is")) {
+      return new String[]{sanitized, GET_PREFIX + str, IS_PREFIX + str};
+    }
     return new String[]{IS_PREFIX + str, GET_PREFIX + str};
   }
 
@@ -438,6 +444,15 @@ public class PropertyUtilBase {
     @NonNls StringBuilder name = new StringBuilder(StringUtil.capitalizeWithJavaBeanConvention(sanitizeJavaIdentifier));
     name.insert(0, setterPrefix);
     return name.toString();
+  }
+
+  public static String[] suggestSetterNames(@NonNls @NotNull String propertyName) {
+    String sanitized = StringUtil.sanitizeJavaIdentifier(propertyName);
+    String str = StringUtil.capitalizeWithJavaBeanConvention(sanitized);
+    if (checkPrefix(sanitized, "is")) {
+      return new String[]{SET_PREFIX + str.substring(2), SET_PREFIX + str};
+    }
+    return new String[]{SET_PREFIX + str};
   }
 
   /**


### PR DESCRIPTION
Fix IDEA-212454 Find usages does not detect generated boolean accessors correctly on find field usages

For the following boolean fields
- isActive
- myIsActiveField (with code style: field prefix = "my", field postfix = "Field"

IntelliJ now additionally detects:

Getter: isActive()
Setter: setActive()

 See PR 1134 in origin repo