### PR TITLE
[FIX] Error when no args passed to script.

### DIFF
--- a/python/helpers/idle.py
+++ b/python/helpers/idle.py
@@ -2,7 +2,7 @@ import sys
 import time
 
 if __name__ == '__main__':
-    if len(sys.argv) > 0:
+    if len(sys.argv) > 1:
         started_message = sys.argv[1]
         print(started_message)
 


### PR DESCRIPTION
if no args passed
```
if len(sys.argv) > 0:
        started_message = sys.argv[1]
        ...
```
IndexError: list index out of range
 See PR 1125 in origin repo