### PR TITLE
IDEA-205705 Include file name in tab title for pom.xml and gradle build scripts (like plugin.xml)

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/util/GradleEditorTabTitleProvider.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/util/GradleEditorTabTitleProvider.java
@@ -31,7 +31,7 @@ public class GradleEditorTabTitleProvider implements EditorTabTitleProvider, Dum
   public String getEditorTabTitle(@NotNull Project project, @NotNull VirtualFile file) {
     if (GradleConstants.DEFAULT_SCRIPT_NAME.equals(file.getName()) || GradleConstants.KOTLIN_DSL_SCRIPT_NAME.equals(file.getName())) {
       Module module = ProjectFileIndex.SERVICE.getInstance(project).getModuleForFile(file);
-      return module == null ? null : module.getName();
+      return module == null ? null : String.format("%s (%s)", file.getName(), module.getName());
     }
 
     return null;

--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/utils/MavenEditorTabTitleProvider.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/utils/MavenEditorTabTitleProvider.java
@@ -30,7 +30,7 @@ public class MavenEditorTabTitleProvider implements EditorTabTitleProvider, Dumb
     if (projectsManager.isMavenizedProject()) {
       MavenProject mavenProject = projectsManager.findProject(file);
       if (mavenProject != null) {
-        return mavenProject.getMavenId().getArtifactId();
+        return String.format("%s (%s)", file.getName(), mavenProject.getMavenId().getArtifactId());
       }
     }
 


### PR DESCRIPTION
Fixes IDEA-205705 Access Gradle and Maven files easier via Recent files by including file name in title

https://youtrack.jetbrains.net/issue/IDEA-205705

Same format used as in org.jetbrains.idea.devkit.dom.ide.PluginDescriptorEditorTabTitleProvider.getEditorTabTitle
 See PR 1033 in origin repo