### PR TITLE
Fix #2 IDEA-141538: XML validator does not use a relative path to the XSD

### DIFF
--- a/xml/xml-psi-impl/src/com/intellij/xml/util/XmlResourceResolver.java
+++ b/xml/xml-psi-impl/src/com/intellij/xml/util/XmlResourceResolver.java
@@ -40,6 +40,7 @@ import java.io.StringReader;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -225,17 +226,12 @@ public class XmlResourceResolver implements XMLEntityResolver {
                   xmlResourceIdentifier.getLiteralSystemId():
                   xmlResourceIdentifier.getNamespace();
 
-    if (publicId != null) {
-      try {
-        String userDir = new File(System.getProperty("user.dir")).toURI().getPath();
-        String publicIdPath = new URI(publicId).getPath();
-        if (publicIdPath.startsWith(userDir)) {
-          publicId = publicIdPath.substring(publicIdPath.indexOf(userDir) + userDir.length());
-        }
-      }
-      catch (Exception e) {
-      }
+    if (publicId != null && publicId.startsWith("file:")) {
+      Path basePath = new File(URI.create(xmlResourceIdentifier.getBaseSystemId())).getParentFile().toPath();
+      Path publicIdPath = new File(URI.create(publicId)).toPath();
+      publicId = basePath.relativize(publicIdPath).toString().replace(File.separatorChar, '/');
     }
+
     PsiFile psiFile = resolve(xmlResourceIdentifier.getBaseSystemId(), publicId);
     if (psiFile == null && xmlResourceIdentifier.getBaseSystemId() != null) {
         psiFile = ExternalResourceManager.getInstance().getResourceLocation(xmlResourceIdentifier.getBaseSystemId(), myFile, null);


### PR DESCRIPTION
This is a continue of my previous already closed PR: https://github.com/JetBrains/intellij-community/pull/1014 (Fix IDEA-141538: XML validator does not use a relative path to the XSD) that was partially accepted.

Please assign to @dmitry-avdeev 
 See PR 1021 in origin repo