### PR TITLE
[external-system] don't always validate recursively

### DIFF
--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/ExternalProjectsDataStorage.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/ExternalProjectsDataStorage.java
@@ -332,14 +332,21 @@ public class ExternalProjectsDataStorage implements SettingsSavingComponent, Per
         continue;
       }
 
-      ExternalSystemApiUtil.visit(externalProject.getExternalProjectStructure(), dataNode -> {
-        try {
-          dataNode.checkIsSerializable();
-        }
-        catch (IOException e) {
-          dataNode.clear(true);
-        }
-      });
+      DataNode<ProjectData> externalProjectStructure = externalProject.getExternalProjectStructure();
+      try {
+        externalProjectStructure.checkIsSerializable();
+      }
+      catch (IOException e) {
+        // try to identify a node which is not serializable and fix it
+        ExternalSystemApiUtil.visit(externalProjectStructure, dataNode -> {
+          try {
+            dataNode.checkIsSerializable();
+          }
+          catch (IOException ignored) {
+            dataNode.clear(true);
+          }
+        });
+      }
     }
 
     DataOutputStream out = new DataOutputStream(new BufferedOutputStream(Files.newOutputStream(projectConfigurationFile)));


### PR DESCRIPTION
`checkIsSerializable` is simply trying to write the object to noop object writer. Let's first see if we can serialize at all and if not try to find a particular node and fix it.

This fixes a nasty ~20 seconds UI freeze on updating project data.

to: @vladsoroka @nskvortsov 
 See PR 1011 in origin repo