### PR TITLE
[external-system] faster module select

### DIFF
--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/ui/ExternalProjectDataSelectorDialog.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/ui/ExternalProjectDataSelectorDialog.java
@@ -523,22 +523,15 @@ public class ExternalProjectDataSelectorDialog extends DialogWrapper {
         }
         parent.isChecked = true;
 
-        final DataNode modifiedParentDataNode = getModifiableDataNode(parent.myDataNode);
-        modifiedParentDataNode.setIgnored(false);
+        setNodeIgnored(parent.myDataNode, false);
 
         if (moduleNode != null) {
           moduleNode.isChecked = true;
         }
-        ExternalSystemApiUtil.visit(moduleNode == null ? myDataNode : moduleNode.myDataNode, node -> {
-          final DataNode modifiedDataNode = getModifiableDataNode(node);
-          modifiedDataNode.setIgnored(false);
-        });
+        setNodeIgnored(moduleNode == null ? myDataNode : moduleNode.myDataNode, false);
       }
       else {
-        ExternalSystemApiUtil.visit(myDataNode, node -> {
-          final DataNode modifiedDataNode = getModifiableDataNode(node);
-          modifiedDataNode.setIgnored(true);
-        });
+        setNodeIgnored(myDataNode, true);
         if (myShowSelectedRowsOnly) {
           final DefaultTreeModel treeModel = (DefaultTreeModel)myTree.getModel();
           TreePath[] before = myTree.getSelectionPaths();
@@ -575,6 +568,12 @@ public class ExternalProjectDataSelectorDialog extends DialogWrapper {
       if (selectionState.getValue().isRequiredSelectionEnabled && isCheckCompleted) {
         warnAboutMissedDependencies(checked);
       }
+    }
+
+    private void setNodeIgnored(@Nullable DataNode node, boolean ignored) {
+      if (node == null) return;
+      final DataNode modifiedDataNode = getModifiableDataNode(node);
+      modifiedDataNode.setIgnored(ignored);
     }
 
     private void warnAboutMissedDependencies(boolean checked) {


### PR DESCRIPTION
There is no need to explicitly set selected state for nodes. It will be taken care of by `CheckboxTree`.

I've tested it on a multi-project. Just selected/deselected node.

I found it while profiling a ~20 seconds UI freeze while operating with select project dialog.

to: @vladsoroka @nskvortsov 
 See PR 1010 in origin repo