### PR TITLE
Add OpenJ9 support to Windows Launchers.

### DIFF
--- a/native/WinLauncher/WinLauncher/WinLauncher.cpp
+++ b/native/WinLauncher/WinLauncher/WinLauncher.cpp
@@ -77,7 +77,7 @@ bool IsValidJRE(const char* path)
   {
     dllPath += "\\";
   }
-  return FileExists(dllPath + "bin\\server\\jvm.dll") || FileExists(dllPath + "bin\\client\\jvm.dll");
+  return FileExists(dllPath + "bin\\server\\jvm.dll") || FileExists(dllPath + "bin\\client\\jvm.dll") || FileExists(dllPath + "bin\\j9vm\\jvm.dll");
 }
 
 bool Is64BitJRE(const char* path)
@@ -584,10 +584,15 @@ bool LoadJVMLibrary()
   TCHAR currentDir[MAX_PATH];
   std::string serverDllName = binDir + "\\server\\jvm.dll";
   std::string clientDllName = binDir + "\\client\\jvm.dll";
-  if ((bServerJVM && FileExists(serverDllName)) || !FileExists(clientDllName))
+  std::string j9DllName = binDir + "\\j9vm\\jvm.dll";
+  
+  if (FileExists(j9DllName)) {
+	  dllName = j9DllName;
+  }
+  else if ((bServerJVM && FileExists(serverDllName)) || !FileExists(clientDllName))
   {
     dllName = serverDllName;
-  }
+  }  
   else
   {
     dllName = clientDllName;


### PR DESCRIPTION
This is a proposed fix for https://youtrack.jetbrains.com/issue/IDEA-202981 and makes the Windows launcher comptatible with OpenJ9. The only changes are path checks for the OpenJ9 jvm.dll locations.

However, I tested it by manually copying the .exe generated by the sln, so some help to understand how the executables are generated for each version of IntelliJ would be appreciated.
 See PR 994 in origin repo