### PR TITLE
Add the ability to highlight java primitives separately from keywords.

### DIFF
--- a/java/java-analysis-impl/src/com/intellij/ide/highlighter/JavaFileHighlighter.java
+++ b/java/java-analysis-impl/src/com/intellij/ide/highlighter/JavaFileHighlighter.java
@@ -29,6 +29,7 @@ public class JavaFileHighlighter extends SyntaxHighlighterBase {
     ourMap2 = new HashMap<>();
 
     fillMap(ourMap1, ElementType.KEYWORD_BIT_SET, JavaHighlightingColors.KEYWORD);
+    fillMap(ourMap1, ElementType.PRIMITIVE_TYPE_BIT_SET, JavaHighlightingColors.PRIMITIVE);
     fillMap(ourMap1, ElementType.LITERAL_BIT_SET, JavaHighlightingColors.KEYWORD);
     fillMap(ourMap1, ElementType.OPERATION_BIT_SET, JavaHighlightingColors.OPERATION_SIGN);
 

--- a/java/java-analysis-impl/src/com/intellij/ide/highlighter/JavaHighlightingColors.java
+++ b/java/java-analysis-impl/src/com/intellij/ide/highlighter/JavaHighlightingColors.java
@@ -32,6 +32,8 @@ public class JavaHighlightingColors {
     = TextAttributesKey.createTextAttributesKey("JAVA_DOC_COMMENT", DefaultLanguageHighlighterColors.DOC_COMMENT);
   public static final TextAttributesKey KEYWORD 
     = TextAttributesKey.createTextAttributesKey("JAVA_KEYWORD", DefaultLanguageHighlighterColors.KEYWORD);
+  public static final TextAttributesKey PRIMITIVE 
+    = TextAttributesKey.createTextAttributesKey("JAVA_PRIMITIVE", DefaultLanguageHighlighterColors.KEYWORD);
   public static final TextAttributesKey NUMBER 
     = TextAttributesKey.createTextAttributesKey("JAVA_NUMBER", DefaultLanguageHighlighterColors.NUMBER);
   public static final TextAttributesKey STRING 

--- a/java/java-impl/src/com/intellij/openapi/options/colors/pages/JavaColorSettingsPage.java
+++ b/java/java-impl/src/com/intellij/openapi/options/colors/pages/JavaColorSettingsPage.java
@@ -42,6 +42,7 @@ import java.util.Map;
 public class JavaColorSettingsPage implements RainbowColorSettingsPage, InspectionColorSettingsPage, DisplayPrioritySortable {
   private static final AttributesDescriptor[] ourDescriptors = {
     new AttributesDescriptor(OptionsBundle.message("options.java.attribute.descriptor.keyword"), JavaHighlightingColors.KEYWORD),
+    new AttributesDescriptor(OptionsBundle.message("options.java.attribute.descriptor.primitive"), JavaHighlightingColors.PRIMITIVE),
     new AttributesDescriptor(OptionsBundle.message("options.java.attribute.descriptor.number"), JavaHighlightingColors.NUMBER),
 
     new AttributesDescriptor(OptionsBundle.message("options.java.attribute.descriptor.string"), JavaHighlightingColors.STRING),

--- a/java/java-tests/testSrc/com/intellij/java/editor/JavaEditorTextAttributesTest.java
+++ b/java/java-tests/testSrc/com/intellij/java/editor/JavaEditorTextAttributesTest.java
@@ -139,6 +139,7 @@ public class JavaEditorTextAttributesTest extends LightPlatformTestCase {
       "JAVA_DOT { color: #000000;  font-style: normal; }\n" +
       "JAVA_INVALID_STRING_ESCAPE { color: #008000;  background-color: #ffcccc;  font-style: normal; }\n" +
       "JAVA_KEYWORD { color: #000080;  font-style: normal;  font-weight: bold; }\n" +
+      "JAVA_PRIMITIVE { color: #000080;  font-style: normal;  font-weight: bold; }\n" +
       "JAVA_LINE_COMMENT { color: #808080;  font-style: italic; }\n" +
       "JAVA_NUMBER { color: #0000ff;  font-style: normal; }\n" +
       "JAVA_OPERATION_SIGN { color: #000000;  font-style: normal; }\n" +
@@ -191,6 +192,7 @@ public class JavaEditorTextAttributesTest extends LightPlatformTestCase {
       "JAVA_DOT { color: #a9b7c6;  font-style: normal; }\n" +
       "JAVA_INVALID_STRING_ESCAPE { color: #6a8759;  font-style: normal; text-decoration: underline #ff0000wavy; }\n" +
       "JAVA_KEYWORD { color: #cc7832;  font-style: normal; }\n" +
+      "JAVA_PRIMITIVE { color: #cc7832;  font-style: normal; }\n" +
       "JAVA_LINE_COMMENT { color: #808080;  font-style: normal; }\n" +
       "JAVA_NUMBER { color: #6897bb;  font-style: normal; }\n" +
       "JAVA_OPERATION_SIGN { color: #a9b7c6;  font-style: normal; }\n" +

--- a/platform/platform-resources-en/src/messages/OptionsBundle.properties
+++ b/platform/platform-resources-en/src/messages/OptionsBundle.properties
@@ -71,6 +71,7 @@ options.java.attribute.descriptor.deprecated.symbol=Errors and Warnings//Depreca
 options.java.attribute.descriptor.marked.for.removal.symbol=Errors and Warnings//Deprecated symbol marked for removal
 options.java.attribute.descriptor.unused.symbol=Errors and Warnings//Unused symbol
 options.java.attribute.descriptor.runtime=Errors and Warnings//Runtime problem
+options.java.attribute.descriptor.primitive=Classes and Interfaces//Primitive
 options.java.attribute.descriptor.class=Classes and Interfaces//Class
 options.java.attribute.descriptor.anonymous.class=Classes and Interfaces//Anonymous class
 options.java.attribute.descriptor.type.parameter=Parameters//Type parameter


### PR DESCRIPTION
Add the ability to highlight java primitives separately from keywords. This leaves the default highlighting unchanged (ie. the same as keywords).

![image](https://user-images.githubusercontent.com/2286456/45606759-d119ab00-ba15-11e8-8002-ce12a9194b34.png)

The README.md doesn't cover running tests, so lmk if there's anything else I should do.

(CLA should be good from intellij-rust contributions)
 See PR 860 in origin repo