### PR TITLE
IDEA-189919 provide a setting for property comments not convert to ascii

### DIFF
--- a/platform/boot/src/com/intellij/lang/properties/charset/Native2AsciiCharsetEncoder.java
+++ b/platform/boot/src/com/intellij/lang/properties/charset/Native2AsciiCharsetEncoder.java
@@ -23,12 +23,18 @@ import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CoderResult;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 class Native2AsciiCharsetEncoder extends CharsetEncoder {
 
   @SuppressWarnings("UseOfArchaicSystemPropertyAccessors")
   private static final char ANCHOR = Boolean.getBoolean("idea.native2ascii.lowercase") ? 'a' : 'A';
-  
+  private static final boolean DO_NOT_CONVERT_COMMENTS = Boolean.getBoolean("idea.native2ascii.skip.comments");
+  private static final String LINE_SEPARATOR =
+    System.getProperty("idea.native2ascii.line.separator") == null ? "\r\n" : System.getProperty("idea.native2ascii.line.separator");
+
   private final Charset myBaseCharset;
 
   public Native2AsciiCharsetEncoder(Native2AsciiCharset charset) {
@@ -38,22 +44,36 @@ class Native2AsciiCharsetEncoder extends CharsetEncoder {
 
   @Override
   protected CoderResult encodeLoop(CharBuffer in, ByteBuffer out) {
+    StringBuilder currentLine = new StringBuilder();
+    List<Character> characters = new ArrayList<>();
+    boolean continueFlg = false;
+    boolean lastIsComment = false;
+
     while (in.position() < in.limit()) {
-      in.mark();
       try {
+        in.mark();
         char c = in.get();
-        if (c < '\u0080') {
-          ByteBuffer byteBuffer = myBaseCharset.encode(Character.toString(c));
-          out.put(byteBuffer);
+        if (isLineEnd(c) || in.position() == in.limit()) {
+          characters.add(c);
+          Character[] array = characters.toArray(new Character[0]);
+          Arrays.stream(array).forEach(character -> currentLine.append(character.charValue()));
+          String str = currentLine.toString();
+          if (DO_NOT_CONVERT_COMMENTS && ((str.startsWith("#") && !continueFlg) || (lastIsComment && continueFlg))) {
+            ByteBuffer byteBuffer = myBaseCharset.encode(str);
+            out.put(byteBuffer);
+            lastIsComment = true;
+          }
+          else {
+            CharBuffer buffer = CharBuffer.wrap(currentLine, 0, currentLine.length());
+            encodeLine(buffer, out);
+            lastIsComment = false;
+          }
+          continueFlg = str.replace(" ", "").endsWith("\\" + LINE_SEPARATOR);
+          currentLine.setLength(0);
+          characters.clear();
         }
         else {
-          if (out.remaining() < 6) throw new BufferOverflowException();
-          out.put((byte)'\\');
-          out.put((byte)'u');
-          out.put(toHexChar(c >> 12));
-          out.put(toHexChar((c >> 8) & 0xf));
-          out.put(toHexChar((c >> 4) & 0xf));
-          out.put(toHexChar(c & 0xf));
+          characters.add(c);
         }
       }
       catch (BufferUnderflowException e) {
@@ -67,10 +87,36 @@ class Native2AsciiCharsetEncoder extends CharsetEncoder {
     return CoderResult.UNDERFLOW;
   }
 
+  private void encodeLine(CharBuffer in, ByteBuffer out) {
+    while (in.position() < in.limit()) {
+      in.mark();
+      char c = in.get();
+      if (c < '\u0080') {
+        ByteBuffer byteBuffer = myBaseCharset.encode(Character.toString(c));
+        out.put(byteBuffer);
+      }
+      else {
+        if (out.remaining() < 6) throw new BufferOverflowException();
+        out.put((byte)'\\');
+        out.put((byte)'u');
+        out.put(toHexChar(c >> 12));
+        out.put(toHexChar((c >> 8) & 0xf));
+        out.put(toHexChar((c >> 4) & 0xf));
+        out.put(toHexChar(c & 0xf));
+      }
+    }
+  }
+
+  private static boolean isLineEnd(char curChar) {
+    char c = LINE_SEPARATOR.charAt(LINE_SEPARATOR.length() - 1);
+    return curChar == c;
+  }
+
   private static byte toHexChar(int digit) {
     if (digit < 10) {
       return (byte)('0' + digit);
     }
     return (byte)(ANCHOR - 10 + digit);
   }
+
 }

--- a/platform/platform-tests/testSrc/com/intellij/lang/TestNative2AsciiCharsetEncoder.java
+++ b/platform/platform-tests/testSrc/com/intellij/lang/TestNative2AsciiCharsetEncoder.java
@@ -1,0 +1,36 @@
+// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.intellij.lang;
+
+import com.intellij.openapi.vfs.CharsetToolkit;
+
+import java.nio.charset.Charset;
+import java.util.Arrays;
+
+/**
+ * @author zhangxinkun
+ */
+public class TestNative2AsciiCharsetEncoder {
+
+  /**
+   * need to depend boot module
+   *
+   * @param args
+   */
+  public static void main(String[] args) {
+    Charset charset =null;
+    //charset = (Native2AsciiCharset)Native2AsciiCharset.wrap(Charset.forName("utf-8"));
+    String s = "#中文\n" +
+               "sdgdsg=etregrere的风格大方会让大哥 \n" +
+               "sdgdg中=dsgdg\n" +
+               "#是的个地方规范  东方宾馆的方便  东方化工的风格#\n" +
+               "sdgfdg=dfgf#dg水电费多少 \n" +
+               "#中问\n" +
+               "#sss中改为\n" +
+               "sdg啥fdg=dfgf#dg水电费多少 \n" +
+               "sdgf算啦dd#d啦g=dfgf#dg水电费多少 \n" +
+               "sds啦s#egfd啦g=dfgf#dg水电费多少 \n";
+    byte[] bytes = s.getBytes(charset);
+    System.out.println(Arrays.toString(bytes));
+    System.out.println(new String(bytes, CharsetToolkit.UTF8_CHARSET));
+  }
+}


### PR DESCRIPTION
* Provide a feature like eclipse properties editor plugin：
![pic](https://user-images.githubusercontent.com/7759897/38593070-1b82443e-3d72-11e8-996b-f1ff33686cc1.jpg)


* default behavior is convert comments, if you don't want to convert comments to ascii,  a string below need add to the $IDEA_INSTALLATION/bin/idea.properties
`idea.native2ascii.skip.comments=true`
* then, you need to add a string to tell IDEA what line sperator in use.  by default, it is "\r\n",you can change to "\n" or "\r"
 `idea.native2ascii.line.separator=\r\n`


 See PR 778 in origin repo