### PR TITLE
Polish characters work regardless of locale

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/keymap/impl/IdeKeyEventDispatcher.java
+++ b/platform/platform-impl/src/com/intellij/openapi/keymap/impl/IdeKeyEventDispatcher.java
@@ -146,17 +146,17 @@ public final class IdeKeyEventDispatcher implements Disposable {
     }
 
     // http://www.jetbrains.net/jira/browse/IDEADEV-12372
-    if (e.getKeyCode() == KeyEvent.VK_CONTROL) {
+    if (e.getKeyCode() == KeyEvent.VK_CONTROL && e.getKeyLocation() == KeyEvent.KEY_LOCATION_LEFT) {
       if (e.getID() == KeyEvent.KEY_PRESSED) {
-        myLeftCtrlPressed = e.getKeyLocation() == KeyEvent.KEY_LOCATION_LEFT;
+        myLeftCtrlPressed = true;
       }
       else if (e.getID() == KeyEvent.KEY_RELEASED) {
         myLeftCtrlPressed = false;
       }
     }
-    else if (e.getKeyCode() == KeyEvent.VK_ALT) {
+    else if (e.getKeyCode() == KeyEvent.VK_ALT && e.getKeyLocation() == KeyEvent.KEY_LOCATION_RIGHT) {
       if (e.getID() == KeyEvent.KEY_PRESSED) {
-        myRightAltPressed = e.getKeyLocation() == KeyEvent.KEY_LOCATION_RIGHT;
+        myRightAltPressed = true;
       }
       else if (e.getID() == KeyEvent.KEY_RELEASED) {
         myRightAltPressed = false;
@@ -381,10 +381,6 @@ public final class IdeKeyEventDispatcher implements Disposable {
     return inInitState();
   }
 
-  @NonNls private static final Set<String> ALT_GR_LAYOUTS = new HashSet<>(Arrays.asList(
-    "pl", "de", "fi", "fr", "no", "da", "se", "pt", "nl", "tr", "sl", "hu", "bs", "hr", "sr", "sk", "lv"
-  ));
-
   private boolean inInitState() {
     Component focusOwner = myContext.getFocusOwner();
     boolean isModalContext = myContext.isModalContext();
@@ -392,21 +388,10 @@ public final class IdeKeyEventDispatcher implements Disposable {
     KeyEvent e = myContext.getInputEvent();
 
     // http://www.jetbrains.net/jira/browse/IDEADEV-12372
-    if (myLeftCtrlPressed && myRightAltPressed && focusOwner != null && e.getModifiers() == (InputEvent.CTRL_MASK | InputEvent.ALT_MASK)) {
-      if (Registry.is("actionSystem.force.alt.gr")) {
-        return false;
-      }
-      final InputContext inputContext = focusOwner.getInputContext();
-      if (inputContext != null) {
-        Locale locale = inputContext.getLocale();
-        if (locale != null) {
-          @NonNls final String language = locale.getLanguage();
-          if (ALT_GR_LAYOUTS.contains(language)) {
-            // don't search for shortcuts
-            return false;
-          }
-        }
-      }
+    if (myLeftCtrlPressed && myRightAltPressed && focusOwner != null &&
+        (e.getModifiers() | InputEvent.SHIFT_MASK) == (InputEvent.CTRL_MASK | InputEvent.ALT_MASK | InputEvent.SHIFT_MASK) &&
+        e.getKeyChar() != KeyEvent.CHAR_UNDEFINED) {
+      return false;
     }
 
     KeyStroke originalKeyStroke = KeyStrokeAdapter.getDefaultKeyStroke(e);


### PR DESCRIPTION
On Windows, Polish keyboard layout (and a few others) remaps Right Alt to
AltGr (Alt Graph) key. For such keyboard layouts pressing right Alt
sends two key press events: Left Ctrl and Right Alt. This is due to a
fact that Ctrl+Alt is also used in Windows as a AltGr key mapping.

On such keyboards, to access national characters users have following
options: Ctrl(any) + Alt (any) + letter or Right Alt + Letter with vast
majority of users using the latter.

Unfortunately, Android Studio uses plenty of shortcuts in form of
Ctrl+Alt+letter. These shortcuts take precedence over typing the accented
character. To make things work, Android Studio uses current locale to
detect if Polish keyboard layout (or another with similar property) is used.

This is not ideal - locale is not equal to keyboard layout. Users who
have English locale, but use Polish keyboard are not able to enter
accented characters that have keybinding mapping defined for them. There
are two workarounds, none of them satisfactory: add a custom property to
idea.properties file (hard to discover) or remove keybindings for each
accented letter.

Fix:
Java sets keyChar property on KeyEvent whenever a key combination would
result in typing a character. If the property is set and it would be a
result of pressing Left Ctrl+Right Alt then ignore and shortcut mappings
to give precedence to typing a character.

Other changes:
* Removed the workaround as it is no longer needed.
* Cleaned up the code that tracks left ctrl/right alt. It didn't work
  correctly when both left and right Ctrl keys/Alt keys were pressed.
* The workaround did not work for uppercase characters due to missing
  check for the Shift key.

See Android Studio issue for more context: https://issuetracker.google.com/68750785

Change-Id: I840ffcc9e653ca6e8942242c017056dc1252e1e0
Test: added IdeKeyEventDispatcherTest.testPolish()
 See PR 752 in origin repo