### PR TITLE
[Fernflower] Ignore library classes when saving decompilation result

### DIFF
--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
@@ -92,6 +92,9 @@ public class ContextUnit {
         // classes
         for (int i = 0; i < classes.size(); i++) {
           StructClass cl = classes.get(i);
+          if (!cl.isOwn()) {
+            continue;
+          }
           String entryName = decompiledData.getClassEntryName(cl, classEntries.get(i));
           if (entryName != null) {
             String content = decompiledData.getClassContent(cl);
@@ -128,6 +131,9 @@ public class ContextUnit {
         // classes
         for (int i = 0; i < classes.size(); i++) {
           StructClass cl = classes.get(i);
+          if (!cl.isOwn()) {
+            continue;
+          }
           String entryName = decompiledData.getClassEntryName(cl, classEntries.get(i));
           if (entryName != null) {
             String content = decompiledData.getClassContent(cl);


### PR DESCRIPTION
I have found a bug where, in some cases, an NPE is thrown because fernflower tries to get the `ClassNode` of a class added as a library (not `isOwn`).

### Example

Test.java:
```
public class Test {
}
```

TestLib.java:
```
public class TestLib {
}
```
Then compile these classes to `Test.class` and `TestLib.class`

On decompiling `Test.class` with `TestLib.class` added as a library, the following error is thrown:
```
$ java -jar fernflower.jar -e=TestLib.class Test.class out
INFO:  Decompiling class Test
INFO:  ... done
Exception in thread "main" java.lang.NullPointerException
        at org.jetbrains.java.decompiler.main.Fernflower.getClassEntryName(Fernflower.java:73)
        at org.jetbrains.java.decompiler.struct.ContextUnit.save(ContextUnit.java:95)
        at org.jetbrains.java.decompiler.struct.StructContext.saveContext(StructContext.java:58)
        at org.jetbrains.java.decompiler.main.Fernflower.decompileContext(Fernflower.java:47)
        at org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler.decompileContext(ConsoleDecompiler.java:115)
        at org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler.main(ConsoleDecompiler.java:81)
```

### Cause

`ClassesProcessor` [only adds classes marked as `isOwn`](https://github.com/JetBrains/intellij-community/blob/3ccefd5764a897e5f9b269f3665c9853cdc370dc/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java#L60) to [`mapRootClasses`](https://github.com/JetBrains/intellij-community/blob/3ccefd5764a897e5f9b269f3665c9853cdc370dc/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java#L117). Therefore, invoking [`getClassEntryName`](https://github.com/JetBrains/intellij-community/blob/3ccefd5764a897e5f9b269f3665c9853cdc370dc/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/Fernflower.java#L72) on a library class will return a null node, hence the NPE.

This patch ensures that `getClassEntryName` is only called on non-library classes.

Adding library classes with `-e=` doesn't cause any issues if added as a `.jar` or `.zip`. This is because the entire `ContextUnit` representing the archive has `own` set to false. Therefore [`saveContext` skips it entirely](https://github.com/JetBrains/intellij-community/blob/3ccefd5764a897e5f9b269f3665c9853cdc370dc/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/struct/StructContext.java#L57).

The NPE only occurs if both library and non-library classes are added to the same `ContextUnit`.

### Fix
Ensure that `getClassEntryName` is only called on non-library classes when saving.

There are alternative ways to fix it too, such as making `getClassEntryName` gracefully return null if the class does not exist, but that may hide other bugs.

Alternatively, `ContextUnit` could enforce that all classes have the same `isOwn` value. I'm thinking this would be a better fix but requires a bit of refactoring.

### Misc

I have signed the CLA.
 See PR 750 in origin repo