### PR TITLE
prevent django_manage.py from tracking changes in node_modules

### DIFF
--- a/python/helpers/pycharm/_jb_utils.py
+++ b/python/helpers/pycharm/_jb_utils.py
@@ -28,7 +28,7 @@ class FileChangesTracker(object):
     def _get_changes_from(folder, patterns):
         result = {}
         for tmp_folder, sub_dirs, files in os.walk(folder):
-            sub_dirs[:] = [s for s in sub_dirs if not s.startswith(".")]
+            sub_dirs[:] = [s for s in sub_dirs if not s.startswith(".") and s != 'node_modules']
             if any(fnmatch.fnmatch(os.path.basename(tmp_folder), p) for p in patterns):
                 for file in map(lambda f: os.path.join(tmp_folder, f), files):
                     try:


### PR DESCRIPTION
The patch prevents `manage.py` console in PyCharm from being painfully slow when there is a `node_modules` somewhere in the project tree.

Timings from my current project, running `migrate` command from `manage.py` console in PyCharm:
- with the patch: 7 sec
- without the patch: 5 min 19 sec

Developers are not supposed to manually change the contents of `node_modules`, so I guess it's fine to exclude it from tracking. I also think it is ok to just hardcode `node_modules` in the method code, because it is hardcoded in Node and [developers cannot rename it](https://stackoverflow.com/a/21818724).
 See PR 712 in origin repo