### PR TITLE
Improvements to “Execute Line in Console” feature in PyCharm.

### DIFF
--- a/python/src/META-INF/python-core-common.xml
+++ b/python/src/META-INF/python-core-common.xml
@@ -786,6 +786,19 @@
       <keyboard-shortcut keymap="NetBeans 6.5" first-keystroke="ctrl alt E" replace-all="true"/>
     </action>
 
+    <action id="SmartExecuteInPyConsoleAction"
+            class="com.jetbrains.python.actions.PySmartExecuteSelectionAction"
+            text="Smart execute selection in console"
+            description="Smart executes selected code fragment in Python/Django console">
+      <add-to-group group-id="EditorPopupMenu" anchor="before" relative-to-action="ExecuteInPyConsoleAction"/>
+
+      <keyboard-shortcut keymap="$default" first-keystroke="alt shift A"/>
+      <keyboard-shortcut keymap="Mac OS X" first-keystroke="control shift A" />
+      <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="control shift A" />
+      <keyboard-shortcut keymap="Eclipse" first-keystroke="ctrl alt A" replace-all="true"/>
+      <keyboard-shortcut keymap="NetBeans 6.5" first-keystroke="ctrl alt A" replace-all="true"/>
+    </action>
+
     <action id="PyRunFileInConsole" class="com.jetbrains.python.actions.PyRunFileInConsoleAction">
       <add-to-group group-id="EditorPopupMenu" anchor="after" relative-to-action="ExecuteInPyConsoleAction"/>
     </action>

--- a/python/src/com/jetbrains/python/actions/PyExecuteSelectionAction.java
+++ b/python/src/com/jetbrains/python/actions/PyExecuteSelectionAction.java
@@ -17,14 +17,20 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.wm.IdeFocusManager;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.psi.PsiDocumentManager;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiWhiteSpace;
+import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentManager;
 import com.intellij.util.Consumer;
+import com.intellij.util.DocumentUtil;
 import com.intellij.xdebugger.XDebugSession;
 import com.intellij.xdebugger.XDebuggerManager;
+import com.jetbrains.python.PyTokenTypes;
 import com.jetbrains.python.console.*;
-import com.jetbrains.python.psi.PyFile;
+import com.jetbrains.python.psi.*;
+import com.jetbrains.python.psi.impl.PyIfPartElifImpl;
 import com.jetbrains.python.run.PythonRunConfiguration;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -41,6 +47,106 @@ public class PyExecuteSelectionAction extends AnAction {
     super(EXECUTE_SELECTION_IN_CONSOLE);
   }
 
+
+  private static String getNLinesAfterCaret(Editor editor, int N) {
+    VisualPosition caretPos = editor.getCaretModel().getVisualPosition();
+
+    Pair<LogicalPosition, LogicalPosition> lines = EditorUtil.calcSurroundingRange(editor, caretPos, caretPos);
+
+    LogicalPosition lineStart = lines.first;
+    int start = editor.logicalPositionToOffset(lineStart);
+    int end = DocumentUtil.getLineTextRange(editor.getDocument(), caretPos.getLine() + N).getEndOffset();
+    return editor.getDocument().getCharsSequence().subSequence(start, end).toString();
+  }
+
+  /*
+   returns true if PsiElement not an evaluable Python statement
+   */
+  private static boolean isPartialStatement(PsiElement psiElement) {
+    return psiElement instanceof PyElsePart ||
+           psiElement instanceof PyIfPartElifImpl ||
+           psiElement instanceof PyIfPart ||
+           psiElement instanceof PyWhilePart ||
+           psiElement instanceof PyExceptPart ||
+           psiElement instanceof PyFinallyPart ||
+           psiElement instanceof PyStatementPart ||
+           psiElement instanceof PyStatementList;
+  }
+
+  /*
+  closest parent that is evaluable
+   */
+  private static PsiElement getEvaluableParent(PsiElement psiElement) {
+    if (psiElement.getNode().getElementType() == PyTokenTypes.ELSE_KEYWORD ||
+        psiElement.getNode().getElementType() == PyTokenTypes.ELIF_KEYWORD ||
+        psiElement.getNode().getElementType() == PyTokenTypes.EXCEPT_KEYWORD ||
+        psiElement.getNode().getElementType() == PyTokenTypes.FINALLY_KEYWORD) {
+      psiElement = psiElement.getParent();
+    }
+    return isPartialStatement(psiElement) ? psiElement.getParent() : psiElement;
+  }
+
+  private static void syntaxErrorAction(final AnActionEvent e) {
+    showConsoleAndExecuteCode(e, "# syntax error");
+  }
+
+  private static void smartExecuteCode(final AnActionEvent e, final Editor editor) {
+    final Document document = editor.getDocument();
+    final PsiDocumentManager psiDocumentManager = PsiDocumentManager.getInstance(e.getProject());
+    psiDocumentManager.commitDocument(document);
+    final PsiFile psiFile = psiDocumentManager.getPsiFile(document);
+
+    final VisualPosition caretPos = editor.getCaretModel().getVisualPosition();
+    final int line = caretPos.getLine();
+
+    final int offset = DocumentUtil.getFirstNonSpaceCharOffset(document, line);
+    final PsiElement psiElement = psiFile.findElementAt(offset);
+    int numLinesToSubmit = document.getLineCount() - line;
+    PsiElement lastCommonParent = null;
+    for (int i = 0; line + i < document.getLineCount(); ++i) {
+      final int lineStartOffset = DocumentUtil.getFirstNonSpaceCharOffset(document, line + i);
+      final PsiElement pe = psiFile.findElementAt(lineStartOffset);
+      final PsiElement commonParentRaw = pe == null ? pe.getContainingFile() : PsiTreeUtil.findCommonParent(psiElement, pe);
+      final PsiElement commonParent = getEvaluableParent(commonParentRaw);
+      if (commonParent.getTextOffset() < offset ||
+          commonParent instanceof PyFile) { // at new statement
+        numLinesToSubmit = i;
+        break;
+      }
+      lastCommonParent = commonParent;
+    }
+    if (lastCommonParent == null) {
+      if (psiElement instanceof PsiWhiteSpace) { // if we are at a blank line
+        moveCaretDown(editor);
+        return;
+      }
+      syntaxErrorAction(e);
+      return;
+    }
+
+    String codeToSend =
+      numLinesToSubmit == 0 ? "" :
+      getNLinesAfterCaret(editor, numLinesToSubmit - 1);
+    if (PsiTreeUtil.hasErrorElements(lastCommonParent) ||
+        psiElement.getTextOffset() < offset) {
+      codeToSend = null;
+    }
+    codeToSend = codeToSend == null ? null : codeToSend.trim();
+
+    if (codeToSend != null && !codeToSend.isEmpty()) {
+      showConsoleAndExecuteCode(e, codeToSend);
+    }
+    if (codeToSend != null) {
+      for (int i = 0; i < numLinesToSubmit; ++i) {
+        moveCaretDown(editor);
+      }
+    }
+    else {
+      syntaxErrorAction(e);
+      return;
+    }
+  }
+
   @Override
   public void actionPerformed(@NotNull AnActionEvent e) {
     Editor editor = e.getData(CommonDataKeys.EDITOR);
@@ -50,11 +156,7 @@ public class PyExecuteSelectionAction extends AnAction {
         showConsoleAndExecuteCode(e, selectionText);
       }
       else {
-        String line = getLineUnderCaret(editor);
-        if (line != null) {
-          showConsoleAndExecuteCode(e, line.trim());
-          moveCaretDown(editor);
-        }
+        smartExecuteCode(e, editor);
       }
     }
   }

--- a/python/src/com/jetbrains/python/actions/PySmartExecuteSelectionAction.java
+++ b/python/src/com/jetbrains/python/actions/PySmartExecuteSelectionAction.java
@@ -1,0 +1,136 @@
+// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.jetbrains.python.actions;
+
+import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.LogicalPosition;
+import com.intellij.openapi.editor.VisualPosition;
+import com.intellij.openapi.editor.ex.util.EditorUtil;
+import com.intellij.openapi.util.Pair;
+import com.intellij.psi.PsiDocumentManager;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiWhiteSpace;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.util.DocumentUtil;
+import com.jetbrains.python.PyTokenTypes;
+import com.jetbrains.python.psi.*;
+import com.jetbrains.python.psi.impl.PyIfPartElifImpl;
+import org.jetbrains.annotations.NotNull;
+
+public class PySmartExecuteSelectionAction extends AnAction {
+
+  private static String getNLinesAfterCaret(Editor editor, int N) {
+    VisualPosition caretPos = editor.getCaretModel().getVisualPosition();
+
+    Pair<LogicalPosition, LogicalPosition> lines = EditorUtil.calcSurroundingRange(editor, caretPos, caretPos);
+
+    LogicalPosition lineStart = lines.first;
+    int start = editor.logicalPositionToOffset(lineStart);
+    int end = DocumentUtil.getLineTextRange(editor.getDocument(), caretPos.getLine() + N).getEndOffset();
+    return editor.getDocument().getCharsSequence().subSequence(start, end).toString();
+  }
+
+  /*
+   returns true if PsiElement not an evaluable Python statement
+   */
+  private static boolean isPartialStatement(PsiElement psiElement) {
+    return psiElement instanceof PyElsePart ||
+           psiElement instanceof PyIfPartElifImpl ||
+           psiElement instanceof PyIfPart ||
+           psiElement instanceof PyWhilePart ||
+           psiElement instanceof PyExceptPart ||
+           psiElement instanceof PyFinallyPart ||
+           psiElement instanceof PyStatementPart ||
+           psiElement instanceof PyStatementList;
+  }
+
+  /*
+  closest parent that is evaluable
+   */
+  private static PsiElement getEvaluableParent(PsiElement psiElement) {
+    if (psiElement.getNode().getElementType() == PyTokenTypes.ELSE_KEYWORD ||
+        psiElement.getNode().getElementType() == PyTokenTypes.ELIF_KEYWORD ||
+        psiElement.getNode().getElementType() == PyTokenTypes.EXCEPT_KEYWORD ||
+        psiElement.getNode().getElementType() == PyTokenTypes.FINALLY_KEYWORD) {
+      psiElement = psiElement.getParent();
+    }
+    return isPartialStatement(psiElement) ? psiElement.getParent() : psiElement;
+  }
+
+  private static void syntaxErrorAction(final AnActionEvent e) {
+    PyExecuteSelectionAction.showConsoleAndExecuteCode(e, "# syntax error");
+  }
+
+  private static void smartExecuteCode(final AnActionEvent e, final Editor editor) {
+    final Document document = editor.getDocument();
+    final PsiDocumentManager psiDocumentManager = PsiDocumentManager.getInstance(e.getProject());
+    psiDocumentManager.commitDocument(document);
+    final PsiFile psiFile = psiDocumentManager.getPsiFile(document);
+
+    final VisualPosition caretPos = editor.getCaretModel().getVisualPosition();
+    final int line = caretPos.getLine();
+
+    final int offset = DocumentUtil.getFirstNonSpaceCharOffset(document, line);
+    final PsiElement psiElement = psiFile.findElementAt(offset);
+    int numLinesToSubmit = document.getLineCount() - line;
+    PsiElement lastCommonParent = null;
+    for (int i = 0; line + i < document.getLineCount(); ++i) {
+      final int lineStartOffset = DocumentUtil.getFirstNonSpaceCharOffset(document, line + i);
+      final PsiElement pe = psiFile.findElementAt(lineStartOffset);
+      final PsiElement commonParentRaw = pe == null ? pe.getContainingFile() : PsiTreeUtil.findCommonParent(psiElement, pe);
+      final PsiElement commonParent = getEvaluableParent(commonParentRaw);
+      if (commonParent.getTextOffset() < offset ||
+          commonParent instanceof PyFile) { // at new statement
+        numLinesToSubmit = i;
+        break;
+      }
+      lastCommonParent = commonParent;
+    }
+    if (lastCommonParent == null) {
+      if (psiElement instanceof PsiWhiteSpace) { // if we are at a blank line
+        PyExecuteSelectionAction.moveCaretDown(editor);
+        return;
+      }
+      syntaxErrorAction(e);
+      return;
+    }
+
+    String codeToSend =
+      numLinesToSubmit == 0 ? "" :
+      getNLinesAfterCaret(editor, numLinesToSubmit - 1);
+    if (PsiTreeUtil.hasErrorElements(lastCommonParent) ||
+        psiElement.getTextOffset() < offset) {
+      codeToSend = null;
+    }
+    codeToSend = codeToSend == null ? null : codeToSend.trim();
+
+    if (codeToSend != null && !codeToSend.isEmpty()) {
+      PyExecuteSelectionAction.showConsoleAndExecuteCode(e, codeToSend);
+    }
+    if (codeToSend != null) {
+      for (int i = 0; i < numLinesToSubmit; ++i) {
+        PyExecuteSelectionAction.moveCaretDown(editor);
+      }
+    }
+    else {
+      syntaxErrorAction(e);
+      return;
+    }
+  }
+
+  @Override
+  public void actionPerformed(@NotNull AnActionEvent e) {
+    Editor editor = CommonDataKeys.EDITOR.getData(e.getDataContext());
+    if (editor != null) {
+      final String selectionText = PyExecuteSelectionAction.getSelectionText(editor);
+      if (selectionText != null) {
+        PyExecuteSelectionAction.showConsoleAndExecuteCode(e, selectionText);
+      }
+      else {
+        smartExecuteCode(e, editor);
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR suggests some improvements to the “Execute Line in Console” feature in PyCharm. Currently, that feature submits a line to the Python console, even when the line is an incomplete input. A screencast demonstrating the new feature in this PR is shown below.
![demo](https://drive.google.com/uc?export=download&id=1Mzd0FJWuTTTZTSnbnN7indCFj5Z2rN85)
![pycharm_pull_request_demo](https://user-images.githubusercontent.com/1260178/74063874-6fb5fb80-49bf-11ea-9e75-35f8524e3c58.gif)

In this PR, the following changes are implemented:

When the cursor is on a line and that line is an incomplete input, submit a minimum amount of lines to produce a complete input.

After that, the cursor in the editor is advanced accordingly.



Because of my unfamiliarity with the source code, I have used some code that is clearly not acceptable. I would appreciate if the reviewers can help with improving the code.
 See PR 711 in origin repo