### PR TITLE
Fixes Task issue status being saved in a corrupt fashion for JIRA

### DIFF
--- a/plugins/tasks/tasks-core/src/com/intellij/tasks/actions/CloseTaskAction.java
+++ b/plugins/tasks/tasks-core/src/com/intellij/tasks/actions/CloseTaskAction.java
@@ -21,9 +21,9 @@ import com.intellij.openapi.actionSystem.Presentation;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.tasks.CustomTaskState;
-import com.intellij.tasks.LocalTask;
 import com.intellij.tasks.TaskManager;
 import com.intellij.tasks.TaskRepository;
+import com.intellij.tasks.impl.LocalTaskImpl;
 import com.intellij.tasks.impl.TaskManagerImpl;
 
 /**
@@ -35,7 +35,7 @@ public class CloseTaskAction extends BaseTaskAction {
     Project project = e.getProject();
     assert project != null;
     TaskManagerImpl taskManager = (TaskManagerImpl)TaskManager.getManager(project);
-    LocalTask task = taskManager.getActiveTask();
+    LocalTaskImpl task = (LocalTaskImpl) taskManager.getActiveTask();
     CloseTaskDialog dialog = new CloseTaskDialog(project, task);
     if (dialog.showAndGet()) {
       final CustomTaskState taskState = dialog.getCloseIssueState();


### PR DESCRIPTION
Especially when connected to a JIRA server, there are times where the status will not update correctly upon closing the issue. After analysis between `OpenTaskDialog` and `CloseTaskAction` (because the status would successfully update on opening the task), I noticed that the Task is being saved at different levels of inheritance, potentially corrupting the state that the task is in and so checked for that and cast it so.

Specifically the error message was `Cannot Set State For Issue`
 See PR 707 in origin repo