### PR TITLE
Annotate AnActionEvent parameter in AnAction.update as @NotNull

### DIFF
--- a/platform/editor-ui-api/src/com/intellij/openapi/actionSystem/AnAction.java
+++ b/platform/editor-ui-api/src/com/intellij/openapi/actionSystem/AnAction.java
@@ -225,7 +225,7 @@ public abstract class AnAction implements PossiblyDumbAware {
    *
    * @param e Carries information on the invocation place and data available
    */
-  public void update(AnActionEvent e) {
+  public void update(@NotNull AnActionEvent e) {
   }
 
   /**


### PR DESCRIPTION
I can't find any implementation that actually checks to see if this parameter is NULL. If it was ever NULL I think bad things would happen across the board.

Also, my Kotlin stubs always mark it as AnActionEvent? - changing it to AnActionEvent every time is a bit tedious.
 See PR 672 in origin repo