### PR TITLE
Don't display parameter names for functional interfaces

### DIFF
--- a/java/java-impl/src/com/intellij/codeInsight/hints/JavaInlayParameterHintsProvider.kt
+++ b/java/java-impl/src/com/intellij/codeInsight/hints/JavaInlayParameterHintsProvider.kt
@@ -71,6 +71,8 @@ class JavaInlayParameterHintsProvider : InlayParameterHintsProvider {
       "(format, arg*)",
       "(message)",
       "(message, error)",
+      "(t)",
+      "(t, u)",
       
       "*Exception",
 


### PR DESCRIPTION
Displaying `predicate.test(t: this)` (for `java.util.function.Predicate`) is hardly useful.
 See PR 640 in origin repo