### PR TITLE
simple support for xslt 3.0

### DIFF
--- a/plugins/xpath/xpath-lang/src/org/intellij/lang/xpath/xslt/impl/XsltChecker.java
+++ b/plugins/xpath/xpath-lang/src/org/intellij/lang/xpath/xslt/impl/XsltChecker.java
@@ -67,7 +67,7 @@ public class XsltChecker extends NanoXmlUtil.IXMLBuilderAdapter {
     private void checkVersion(String value, State yes) {
         if (isVersion1(value)) {
             myState = yes;
-        } else if (isVersion2(value)) {
+        } else if (isVersion2(value) || isVersion3(value)) {
             myState = State.VERSION2;
         } else {
             myState = State.NO;
@@ -75,7 +75,7 @@ public class XsltChecker extends NanoXmlUtil.IXMLBuilderAdapter {
     }
 
     public static boolean isSupportedVersion(String value) {
-        return isVersion1(value) || isVersion2(value);
+        return isVersion1(value) || isVersion2(value) || isVersion3(value);
     }
 
     public static boolean isVersion1(String value) {
@@ -84,6 +84,10 @@ public class XsltChecker extends NanoXmlUtil.IXMLBuilderAdapter {
 
     public static boolean isVersion2(String value) {
         return "2.0".equals(value);
+    }
+
+    public static boolean isVersion3(String value) {
+        return "3.0".equals(value);
     }
 
     @Override
@@ -112,6 +116,9 @@ public class XsltChecker extends NanoXmlUtil.IXMLBuilderAdapter {
             return LanguageLevel.V1;
         }
         if (isVersion2(value)) {
+            return LanguageLevel.V2;
+        }
+        if (isVersion3(value)) {
             return LanguageLevel.V2;
         }
         return LanguageLevel.NONE;

--- a/xml/xml-psi-impl/resources/standardSchemas/xslt-3_0.xsd
+++ b/xml/xml-psi-impl/resources/standardSchemas/xslt-3_0.xsd
@@ -1,0 +1,2688 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--* <!DOCTYPE xs:schema PUBLIC "-//W3C//DTD XMLSCHEMA 200105//EN"
+       "http://www.w3.org/2001/XMLSchema.dtd" [
+<!ENTITY % schemaAttrs "
+  xmlns:xs   CDATA #IMPLIED
+  xmlns:xsl  CDATA #IMPLIED
+  xmlns:xsd  CDATA #IMPLIED"
+>
+<!ENTITY % p "xs:">
+<!ENTITY % s ":xs">
+]> *-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+           xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning"
+           targetNamespace="http://www.w3.org/1999/XSL/Transform"
+           elementFormDefault="qualified"
+           vc:minVersion="1.1">
+
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:annotation>
+    <xs:documentation>
+      <p>
+        This is an XSD 1.1 schema for XSLT 3.0 stylesheets. It defines all the
+        elements that appear in the XSLT namespace; it also provides hooks that
+        allow the inclusion of user-defined literal result elements, extension
+        instructions, and top-level data elements.
+      </p>
+      <p>
+        This schema is available for use under the conditions of the W3C Software
+        License published at
+        http://www.w3.org/Consortium/Legal/copyright-software-19980720
+      </p>
+      <p>
+        The schema is organized as follows:
+      </p>
+      <ul>
+        <li>
+          PART A: definitions of complex types and model groups used as the basis
+          for element definitions
+        </li>
+        <li>
+          PART B: definitions of individual XSLT elements
+        </li>
+        <li>
+          PART C: definitions for literal result elements
+        </li>
+        <li>
+          PART D: definitions of simple types used in attribute definitions
+        </li>
+      </ul>
+      <p>
+        The schema has a number of limitations:
+      </p>
+      <ul>
+        <li>
+          The XSLT specification allows additional elements and attributes to be
+          present where forwards compatibility is invoked. This schema does not.
+        </li>
+        <li>
+          The XSLT specification allows arbitrary content in a part of the
+          stylesheet that is excluded by virtue of a use-when attribute. This
+          schema does not.
+        </li>
+        <li>
+          The handling of literal result elements in this schema is imperfect;
+          although various options are allowed, none matches the specification
+          exactly. For example, the content of a literal result element uses lax
+          validation, which permits child elements in the XSLT namespace that have
+          no declaration in this schema.
+        </li>
+        <li>
+          The schema makes no attempt to check XPath expressions for syntactic or
+          semantic correctness, nor to check that component references are
+          resolved (for example that a template named in xsl:call-template has a
+          declaration). Doing this in general requires cross-document validation,
+          which is beyond the scope of XSD.
+        </li>
+        <li>
+          The schema imports the schema for XSD 1.0 schema documents. In
+          stylesheets that contain an inline XSD 1.1 schema, this import should be
+          replaced with one for the schema for XSD 1.1 schema documents.
+        </li>
+      </ul>
+    </xs:documentation>
+  </xs:annotation>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <!--
+The declaration of xml:space and xml:lang may need to be commented out because
+of problems processing the schema using various tools
+-->
+
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace"/>
+  <!--schemaLocation="http://www.w3.org/2001/xml.xsd"-->
+
+  <!--
+    An XSLT stylesheet may contain an in-line schema within an xsl:import-schema element,
+    so the Schema for schemas needs to be imported. We use the XSD 1.1 version.
+-->
+
+  <xs:import namespace="http://www.w3.org/2001/XMLSchema"
+             schemaLocation="http://www.w3.org/TR/xmlschema11-1/XMLSchema.xsd"/>
+
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:annotation>
+    <xs:documentation>
+      <p>
+        PART A: definitions of complex types and model groups used as the basis
+        for element definitions
+      </p>
+    </xs:documentation>
+  </xs:annotation>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <xs:complexType name="generic-element-type" mixed="true">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          This complex type provides a generic supertype for all XSLT elements; it
+          contains the definitions of the standard attributes that may appear on
+          any element.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="default-collation" type="xsl:uri-list"/>
+    <xs:attribute name="default-mode" type="xsl:default-mode-type"/>
+    <xs:attribute name="default-validation"
+                  type="xsl:validation-strip-or-preserve"
+                  default="strip"/>
+    <xs:attribute name="exclude-result-prefixes" type="xsl:prefix-list-or-all"/>
+    <xs:attribute name="expand-text" type="xsl:yes-or-no"/>
+    <xs:attribute name="extension-element-prefixes" type="xsl:prefix-list"/>
+    <xs:attribute name="use-when" type="xsl:expression"/>
+    <xs:attribute name="xpath-default-namespace" type="xs:anyURI"/>
+    <xs:attribute name="_default-collation" type="xs:string"/>
+    <xs:attribute name="_default-mode" type="xs:string"/>
+    <xs:attribute name="_default-validation" type="xs:string"/>
+    <xs:attribute name="_exclude-result-prefixes" type="xs:string"/>
+    <xs:attribute name="_expand-text" type="xs:string"/>
+    <xs:attribute name="_extension-element-prefixes" type="xs:string"/>
+    <xs:attribute name="_use-when" type="xs:string"/>
+    <xs:attribute name="_xpath-default-namespace" type="xs:string"/>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+  </xs:complexType>
+
+  <xs:complexType name="versioned-element-type" mixed="true">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          This complex type provides a generic supertype for all XSLT elements
+          with the exception of xsl:output; it contains the definitions of the
+          version attribute that may appear on any element.
+        </p>
+        <p>
+          The xsl:output does not use this definition because, although it has a
+          version attribute, the syntax and semantics of this attribute are
+          unrelated to the standard version attribute allowed on other elements.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="xsl:generic-element-type">
+        <xs:attribute name="version" type="xs:decimal" use="optional"/>
+        <xs:attribute name="_version" type="xs:string"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="element-only-versioned-element-type" mixed="false">
+    <xs:complexContent>
+      <xs:restriction base="xsl:versioned-element-type">
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="sequence-constructor">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          This complex type provides a generic supertype for all XSLT elements
+          that allow a sequence constructor as their content.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexContent mixed="true">
+      <xs:extension base="xsl:versioned-element-type">
+        <xs:group ref="xsl:sequence-constructor-group"
+                  minOccurs="0"
+                  maxOccurs="unbounded"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="sequence-constructor-and-select">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          This complex type allows a sequence constructor and a select attribute.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexContent mixed="true">
+      <xs:extension base="xsl:sequence-constructor">
+        <xs:attribute name="select" type="xsl:expression"/>
+        <xs:attribute name="_select" type="xs:string"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="sequence-constructor-or-select">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          This complex type allows a sequence constructor or a select attribute,
+          but not both.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexContent mixed="true">
+      <xs:restriction base="xsl:sequence-constructor-and-select">
+        <xs:group ref="xsl:sequence-constructor-group"
+                  minOccurs="0"
+                  maxOccurs="unbounded"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+        <xs:assert test="not(exists(@select | @_select) and
+          (exists(* except xsl:fallback) or exists(text()[normalize-space()])))"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:group name="sequence-constructor-group">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          This complex type provides a generic supertype for all XSLT elements
+          that allow a sequence constructor as their content.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice>
+      <xs:element ref="xsl:instruction"/>
+      <xs:group ref="xsl:result-elements"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:element name="declaration" type="xsl:generic-element-type" abstract="true"/>
+
+  <xs:element name="instruction" type="xsl:versioned-element-type" abstract="true"/>
+
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:annotation>
+    <xs:documentation>
+      <p>
+        PART B: definitions of individual XSLT elements Elements are listed in
+        alphabetical order.
+      </p>
+    </xs:documentation>
+  </xs:annotation>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <xs:element name="accept">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          This element appears as a child of xsl:use-package and defines any
+          variations that the containing package wishes to make to the visibility
+          of components made available from a library package. For example, it may
+          indicate that some of the public components in the library package are
+          not to be made available to the containing package.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:attribute name="component" type="xsl:component-kind-type"/>
+          <xs:attribute name="names" type="xsl:EQNames"/>
+          <xs:attribute name="visibility" type="xsl:visibility-type"/>
+          <xs:attribute name="_component" type="xs:string"/>
+          <xs:attribute name="_names" type="xs:string"/>
+          <xs:attribute name="_visibility" type="xs:string"/>
+          <xs:assert test="exists(@component | @_component)"/>
+          <xs:assert test="exists(@names | @_names)"/>
+          <xs:assert test="exists(@visibility | @_visibility)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="accumulator" substitutionGroup="xsl:declaration">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:sequence>
+            <xs:element ref="xsl:accumulator-rule" minOccurs="1" maxOccurs="unbounded"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="xsl:EQName"/>
+          <xs:attribute name="initial-value" type="xsl:expression"/>
+          <xs:attribute name="as" type="xsl:sequence-type"/>
+          <xs:attribute name="streamable" type="xsl:yes-or-no"/>
+          <xs:attribute name="_name" type="xs:string"/>
+          <xs:attribute name="_initial-value" type="xs:string"/>
+          <xs:attribute name="_as" type="xs:string"/>
+          <xs:attribute name="_streamable" type="xs:string"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="accumulator-rule">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:sequence-constructor-or-select">
+          <xs:sequence/>
+          <xs:attribute name="match" type="xsl:pattern"/>
+          <xs:attribute name="phase">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="start"/>
+                <xs:enumeration value="end"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="_match" type="xs:string"/>
+          <xs:attribute name="_phase" type="xs:string"/>
+          <xs:assert test="exists(@match | @_match)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="analyze-string" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:sequence>
+            <xs:element ref="xsl:matching-substring" minOccurs="0"/>
+            <xs:element ref="xsl:non-matching-substring" minOccurs="0"/>
+            <xs:element ref="xsl:fallback" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+          <xs:attribute name="select" type="xsl:expression"/>
+          <xs:attribute name="regex" type="xsl:avt"/>
+          <xs:attribute name="flags" type="xsl:avt" default=""/>
+          <xs:attribute name="_select" type="xs:string"/>
+          <xs:attribute name="_regex" type="xs:string"/>
+          <xs:attribute name="_flags" type="xs:string"/>
+          <xs:assert test="exists(@select | @_select)"/>
+          <xs:assert test="exists(@regex | @_regex)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="apply-imports" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:sequence>
+            <xs:element ref="xsl:with-param" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="apply-templates" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="xsl:sort"/>
+            <xs:element ref="xsl:with-param"/>
+          </xs:choice>
+          <xs:attribute name="select" type="xsl:expression" default="child::node()"/>
+          <xs:attribute name="mode" type="xsl:mode"/>
+          <xs:attribute name="_select" type="xs:string"/>
+          <xs:attribute name="_mode" type="xs:string"/>
+          <xs:assert test="every $e in subsequence(xsl:sort, 2)
+                           satisfies empty($e/(@stable | @_stable))">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  It is a static error if an xsl:sort element other than the first
+                  in a sequence of sibling xsl:sort elements has a stable
+                  attribute.
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="assert" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:sequence-constructor">
+          <xs:attribute name="test" type="xsl:expression"/>
+          <xs:attribute name="select" type="xsl:expression"/>
+          <xs:attribute name="error-code" type="xsl:avt"/>
+          <xs:attribute name="_test" type="xs:string"/>
+          <xs:attribute name="_select" type="xs:string"/>
+          <xs:attribute name="_error-code" type="xs:string"/>
+          <xs:assert test="exists(@test | @_test)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="attribute" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:sequence-constructor-or-select">
+          <xs:attribute name="name" type="xsl:avt"/>
+          <xs:attribute name="namespace" type="xsl:avt"/>
+          <xs:attribute name="separator" type="xsl:avt"/>
+          <xs:attribute name="type" type="xsl:EQName"/>
+          <xs:attribute name="validation" type="xsl:validation-type"/>
+          <xs:attribute name="_name" type="xs:string"/>
+          <xs:attribute name="_namespace" type="xs:string"/>
+          <xs:attribute name="_separator" type="xs:string"/>
+          <xs:attribute name="_type" type="xs:string"/>
+          <xs:attribute name="_validation" type="xs:string"/>
+          <xs:assert test="not(exists(@type | @_type) and exists(@validation | @_validation))">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  The type and validation attributes are mutually exclusive (if
+                  one is present, the other must be absent).
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+          <xs:assert test="exists(@name | @_name)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="attribute-set" substitutionGroup="xsl:declaration">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="xsl:attribute"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="xsl:EQName"/>
+          <xs:attribute name="streamable" type="xsl:yes-or-no"/>
+          <xs:attribute name="use-attribute-sets" type="xsl:EQNames" default=""/>
+          <xs:attribute name="visibility" type="xsl:visibility-type"/>
+          <xs:attribute name="_name" type="xs:string"/>
+          <xs:attribute name="_streamable" type="xs:string"/>
+          <xs:attribute name="_use-attribute-sets" type="xs:string"/>
+          <xs:attribute name="_visibility" type="xs:string"/>
+          <xs:assert test="exists(@name | @_name)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="break"
+              substitutionGroup="xsl:instruction"
+              type="xsl:sequence-constructor-or-select"/>
+
+  <xs:element name="call-template" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:sequence>
+            <xs:element ref="xsl:with-param" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="xsl:EQName"/>
+          <xs:attribute name="_name" type="xs:string"/>
+          <xs:assert test="exists(@name | @_name)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="catch">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:sequence-constructor-or-select">
+          <xs:attribute name="errors" type="xs:token" use="optional"/>
+          <xs:attribute name="_errors" type="xs:string"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="character-map" substitutionGroup="xsl:declaration">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:sequence>
+            <xs:element ref="xsl:output-character" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="xsl:EQName"/>
+          <xs:attribute name="use-character-maps" type="xsl:EQNames" default=""/>
+          <xs:attribute name="_name" type="xs:string"/>
+          <xs:attribute name="_use-character-maps" type="xs:string"/>
+          <xs:assert test="exists(@name | @_name)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="choose" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:sequence>
+            <xs:element ref="xsl:when" maxOccurs="unbounded"/>
+            <xs:element ref="xsl:otherwise" minOccurs="0"/>
+          </xs:sequence>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="comment"
+              substitutionGroup="xsl:instruction"
+              type="xsl:sequence-constructor-or-select"/>
+
+  <xs:element name="context-item">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:attribute name="as" type="xsl:item-type"/>
+          <xs:attribute name="use">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="required"/>
+                <xs:enumeration value="optional"/>
+                <xs:enumeration value="absent"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="_as" type="xs:string"/>
+          <xs:attribute name="_use" type="xs:string"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="copy" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:sequence-constructor">
+          <xs:attribute name="select" type="xsl:expression"/>
+          <xs:attribute name="copy-namespaces" type="xsl:yes-or-no" default="yes"/>
+          <xs:attribute name="inherit-namespaces" type="xsl:yes-or-no" default="yes"/>
+          <xs:attribute name="use-attribute-sets" type="xsl:EQNames" default=""/>
+          <xs:attribute name="type" type="xsl:EQName"/>
+          <xs:attribute name="validation" type="xsl:validation-type"/>
+          <xs:attribute name="_select" type="xs:string"/>
+          <xs:attribute name="_copy-namespaces" type="xs:string"/>
+          <xs:attribute name="_inherit-namespaces" type="xs:string"/>
+          <xs:attribute name="_use-attribute-sets" type="xs:string"/>
+          <xs:attribute name="_type" type="xs:string"/>
+          <xs:attribute name="_validation" type="xs:string"/>
+          <xs:assert test="not(exists(@type | @_type) and exists(@validation | @_validation))">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  The type and validation attributes are mutually exclusive (if
+                  one is present, the other must be absent).
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="copy-of" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:versioned-element-type">
+          <xs:attribute name="select" type="xsl:expression"/>
+          <xs:attribute name="copy-accumulators" type="xsl:yes-or-no" default="no"/>
+          <xs:attribute name="copy-namespaces" type="xsl:yes-or-no" default="yes"/>
+          <xs:attribute name="type" type="xsl:EQName"/>
+          <xs:attribute name="validation" type="xsl:validation-type"/>
+          <xs:attribute name="_select" type="xs:string"/>
+          <xs:attribute name="_copy-accumulators" type="xs:string"/>
+          <xs:attribute name="_copy-namespaces" type="xs:string"/>
+          <xs:attribute name="_type" type="xs:string"/>
+          <xs:attribute name="_validation" type="xs:string"/>
+          <xs:assert test="not(exists(@type | @_type) and exists(@validation | @_validation))">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  The type and validation attributes are mutually exclusive (if
+                  one is present, the other must be absent).
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+          <xs:assert test="exists(@select | @_select)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="document" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:sequence-constructor">
+          <xs:attribute name="type" type="xsl:EQName"/>
+          <xs:attribute name="validation" type="xsl:validation-type"/>
+          <xs:attribute name="_type" type="xs:string"/>
+          <xs:attribute name="_validation" type="xs:string"/>
+          <xs:assert test="not(exists(@type | @_type) and exists(@validation | @_validation))">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  The type and validation attributes are mutually exclusive (if
+                  one is present, the other must be absent).
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="decimal-format" substitutionGroup="xsl:declaration">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:attribute name="name" type="xsl:EQName"/>
+          <xs:attribute name="decimal-separator" type="xsl:char" default="."/>
+          <xs:attribute name="grouping-separator" type="xsl:char" default=","/>
+          <xs:attribute name="infinity" type="xs:string" default="Infinity"/>
+          <xs:attribute name="minus-sign" type="xsl:char" default="-"/>
+          <xs:attribute name="exponent-separator" type="xsl:char" default="e"/>
+          <xs:attribute name="NaN" type="xs:string" default="NaN"/>
+          <xs:attribute name="percent" type="xsl:char" default="%"/>
+          <xs:attribute name="per-mille" type="xsl:char" default="~"/>
+          <xs:attribute name="zero-digit" type="xsl:zero-digit" default="0"/>
+          <xs:attribute name="digit" type="xsl:char" default="#"/>
+          <xs:attribute name="pattern-separator" type="xsl:char" default=";"/>
+          <xs:attribute name="_name" type="xs:string"/>
+          <xs:attribute name="_decimal-separator" type="xs:string"/>
+          <xs:attribute name="_grouping-separator" type="xs:string"/>
+          <xs:attribute name="_infinity" type="xs:string"/>
+          <xs:attribute name="_minus-sign" type="xs:string"/>
+          <xs:attribute name="_exponent-separator" type="xs:string"/>
+          <xs:attribute name="_NaN" type="xs:string"/>
+          <xs:attribute name="_percent" type="xs:string"/>
+          <xs:attribute name="_per-mille" type="xs:string"/>
+          <xs:attribute name="_zero-digit" type="xs:string"/>
+          <xs:attribute name="_digit" type="xs:string"/>
+          <xs:attribute name="_pattern-separator" type="xs:string"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="element" substitutionGroup="xsl:instruction">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="xsl:sequence-constructor">
+          <xs:attribute name="name" type="xsl:avt"/>
+          <xs:attribute name="namespace" type="xsl:avt"/>
+          <xs:attribute name="inherit-namespaces" type="xsl:yes-or-no" default="yes"/>
+          <xs:attribute name="use-attribute-sets" type="xsl:EQNames" default=""/>
+          <xs:attribute name="type" type="xsl:EQName"/>
+          <xs:attribute name="validation" type="xsl:validation-type"/>
+          <xs:attribute name="_name" type="xs:string"/>
+          <xs:attribute name="_namespace" type="xs:string"/>
+          <xs:attribute name="_inherit-namespaces" type="xs:string"/>
+          <xs:attribute name="_use-attribute-sets" type="xs:string"/>
+          <xs:attribute name="_type" type="xs:string"/>
+          <xs:attribute name="_validation" type="xs:string"/>
+          <xs:assert test="exists(@name | @_name)"/>
+          <xs:assert test="not(exists(@type | @_type) and exists(@validation | @_validation))">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  The type and validation attributes are mutually exclusive (if
+                  one is present, the other must be absent).
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="evaluate" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="xsl:with-param"/>
+            <xs:element ref="xsl:fallback"/>
+          </xs:choice>
+          <xs:attribute name="xpath" type="xsl:expression"/>
+          <xs:attribute name="as" type="xsl:sequence-type"/>
+          <xs:attribute name="base-uri" type="xsl:avt"/>
+          <xs:attribute name="context-item" type="xsl:expression"/>
+          <xs:attribute name="namespace-context" type="xsl:expression"/>
+          <xs:attribute name="schema-aware" type="xsl:avt"/>
+          <xs:attribute name="with-params" type="xsl:expression"/>
+          <xs:attribute name="_xpath" type="xs:string"/>
+          <xs:attribute name="_as" type="xs:string"/>
+          <xs:attribute name="_base-uri" type="xs:string"/>
+          <xs:attribute name="_context-item" type="xs:string"/>
+          <xs:attribute name="_namespace-context" type="xs:string"/>
+          <xs:attribute name="_schema-aware" type="xs:string"/>
+          <xs:attribute name="_with-params" type="xs:string"/>
+          <xs:assert test="exists(@xpath | @_xpath)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="expose">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          This element appears as a child of xsl:use-package and defines the
+          visibility of components that are made available (or not) by this
+          package to other using packages.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:attribute name="component" type="xsl:component-kind-type"/>
+          <xs:attribute name="names" type="xsl:EQNames"/>
+          <xs:attribute name="visibility" type="xsl:visibility-not-hidden-type"/>
+          <xs:attribute name="_component" type="xs:string"/>
+          <xs:attribute name="_names" type="xs:string"/>
+          <xs:attribute name="_visibility" type="xs:string"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="fallback"
+              substitutionGroup="xsl:instruction"
+              type="xsl:sequence-constructor"/>
+
+  <xs:element name="for-each" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:versioned-element-type">
+          <xs:sequence>
+            <xs:element ref="xsl:sort" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:group ref="xsl:sequence-constructor-group"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+          </xs:sequence>
+          <xs:attribute name="select" type="xsl:expression"/>
+          <xs:attribute name="_select" type="xs:string"/>
+          <xs:assert test="every $e in subsequence(xsl:sort, 2)
+                           satisfies empty($e/(@stable | @_stable))">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  It is a static error if an xsl:sort element other than the first
+                  in a sequence of sibling xsl:sort elements has a stable
+                  attribute.
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+          <xs:assert test="exists(@select | @_select)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="for-each-group" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:versioned-element-type">
+          <xs:sequence>
+            <xs:element ref="xsl:sort" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:group ref="xsl:sequence-constructor-group"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+          </xs:sequence>
+          <xs:attribute name="select" type="xsl:expression"/>
+          <xs:attribute name="group-by" type="xsl:expression"/>
+          <xs:attribute name="group-adjacent" type="xsl:expression"/>
+          <xs:attribute name="group-starting-with" type="xsl:pattern"/>
+          <xs:attribute name="group-ending-with" type="xsl:pattern"/>
+          <xs:attribute name="composite" type="xsl:yes-or-no"/>
+          <xs:attribute name="collation" type="xsl:avt"/>
+          <xs:attribute name="_select" type="xs:string"/>
+          <xs:attribute name="_group-by" type="xs:string"/>
+          <xs:attribute name="_group-adjacent" type="xs:string"/>
+          <xs:attribute name="_group-starting-with" type="xs:string"/>
+          <xs:attribute name="_group-ending-with" type="xs:string"/>
+          <xs:attribute name="_composite" type="xs:string"/>
+          <xs:attribute name="_collation" type="xs:string"/>
+          <xs:assert test="exists(@select | @_select)"/>
+          <xs:assert test="every $e in subsequence(xsl:sort, 2)
+                           satisfies empty($e/(@stable | @_stable))">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  It is a static error if an xsl:sort element other than the first
+                  in a sequence of sibling xsl:sort elements has a stable
+                  attribute.
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+          <xs:assert test="count(((@group-by|@_group-by)[1],
+                                  (@group-adjacent|@_group-adjacent)[1],
+                                  (@group-starting-with|@_group-starting-with)[1],
+                                  (@group-ending-with|@_group-ending-with)[1])) = 1">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  These four attributes are mutually exclusive: it is a static
+                  error if none of these four attributes is present or if more
+                  than one of them is present.
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+          <xs:assert test="if (exists(@collation|@_collation) or exists(@composite|@_composite))
+                           then (exists(@group-by|@_group-by) or exists(@group-adjacent|@_group-adjacent))
+                           else true()">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  It is an error to specify the collation attribute or the
+                  composite attribute if neither the group-by attribute nor
+                  group-adjacent attribute is specified.
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="fork" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:versioned-element-type">
+          <xs:sequence>
+            <xs:element ref="xsl:fallback" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:choice>
+              <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                <xs:element ref="xsl:sequence"/>
+                <xs:element ref="xsl:fallback" minOccurs="0" maxOccurs="unbounded"/>
+              </xs:sequence>
+              <xs:sequence>
+                <xs:element ref="xsl:for-each-group"/>
+                <xs:element ref="xsl:fallback" minOccurs="0" maxOccurs="unbounded"/>
+              </xs:sequence>
+            </xs:choice>
+          </xs:sequence>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="function" substitutionGroup="xsl:declaration">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:versioned-element-type">
+          <xs:sequence>
+            <xs:element ref="xsl:param" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:group ref="xsl:sequence-constructor-group"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="xsl:EQName-in-namespace"/>
+          <xs:attribute name="override" type="xsl:yes-or-no" default="yes"/>
+          <xs:attribute name="as" type="xsl:sequence-type" default="item()*"/>
+          <xs:attribute name="visibility" type="xsl:visibility-type"/>
+          <xs:attribute name="streamability" type="xsl:streamability-type"/>
+          <xs:attribute name="override-extension-function" type="xsl:yes-or-no"/>
+          <xs:attribute name="new-each-time" type="xsl:yes-or-no-or-maybe"/>
+          <xs:attribute name="cache" type="xsl:yes-or-no"/>
+          <xs:attribute name="_name" type="xs:string"/>
+          <xs:attribute name="_override" type="xs:string"/>
+          <xs:attribute name="_as" type="xs:string"/>
+          <xs:attribute name="_visibility" type="xs:string"/>
+          <xs:attribute name="_streamability" type="xs:string"/>
+          <xs:attribute name="_override-extension-function" type="xs:string"/>
+          <xs:attribute name="_identity-sensitive" type="xs:string"/>
+          <xs:attribute name="_cache" type="xs:string"/>
+          <xs:assert test="exists(@name | @_name)"/>
+          <xs:assert test="every $e in xsl:param
+                           satisfies (empty($e/(@select | @_select)) and empty($e/child::node()))">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  A parameter for a function must have no default value.
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+          <xs:assert test="every $e in xsl:param satisfies empty($e/(@visibility | @_visibility))">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  A parameter for a function must have no visibility attribute.
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+          <xs:assert test="every $e in xsl:param satisfies empty($e/(@required | @_required))">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  A parameter for a function must have no required attribute.
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="global-context-item" substitutionGroup="xsl:declaration">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:attribute name="as" type="xsl:item-type"/>
+          <xs:attribute name="use">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="required"/>
+                <xs:enumeration value="optional"/>
+                <xs:enumeration value="absent"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="_as" type="xs:string"/>
+          <xs:attribute name="_use" type="xs:string"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+
+  <xs:element name="if" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:sequence-constructor">
+          <xs:attribute name="test" type="xsl:expression"/>
+          <xs:attribute name="_test" type="xs:string"/>
+          <xs:assert test="exists(@test | @_test)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="import" substitutionGroup="xsl:declaration">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:attribute name="href" type="xs:anyURI"/>
+          <xs:attribute name="_href" type="xs:string"/>
+          <xs:assert test="exists(@href | @_href)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="import-schema" substitutionGroup="xsl:declaration">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:sequence>
+            <xs:element ref="xs:schema" minOccurs="0" maxOccurs="1"/>
+          </xs:sequence>
+          <xs:attribute name="namespace" type="xs:anyURI"/>
+          <xs:attribute name="schema-location" type="xs:anyURI"/>
+          <xs:attribute name="_namespace" type="xs:string"/>
+          <xs:attribute name="_schema-location" type="xs:string"/>
+          <xs:assert test="not(exists(@schema-location | @_schema-location) and exists(xs:schema))">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  XTSE0215: It is a static error if an xsl:import-schema element
+                  that contains an xs:schema element has a schema-location
+                  attribute
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="include" substitutionGroup="xsl:declaration">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:attribute name="href" type="xs:anyURI"/>
+          <xs:attribute name="_href" type="xs:string"/>
+          <xs:assert test="exists(@href | @_href)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="iterate" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:versioned-element-type">
+          <xs:sequence>
+            <xs:element ref="xsl:param" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="xsl:on-completion" minOccurs="0" maxOccurs="1"/>
+            <xs:group ref="xsl:sequence-constructor-group"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+          </xs:sequence>
+          <xs:attribute name="select" type="xsl:expression"/>
+          <xs:attribute name="_select" type="xs:string"/>
+          <xs:assert test="exists(@select | @_select)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="key" substitutionGroup="xsl:declaration">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:sequence-constructor">
+          <xs:attribute name="name" type="xsl:EQName"/>
+          <xs:attribute name="match" type="xsl:pattern"/>
+          <xs:attribute name="use" type="xsl:expression"/>
+          <xs:attribute name="composite" type="xsl:yes-or-no"/>
+          <xs:attribute name="collation" type="xs:anyURI"/>
+          <xs:attribute name="_name" type="xs:string"/>
+          <xs:attribute name="_match" type="xs:string"/>
+          <xs:attribute name="_use" type="xs:string"/>
+          <xs:attribute name="_composite" type="xs:string"/>
+          <xs:attribute name="_collation" type="xs:string"/>
+          <xs:assert test="exists(@name | @_name)"/>
+          <xs:assert test="exists(@match | @_match)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="map"
+              type="xsl:sequence-constructor"
+              substitutionGroup="xsl:instruction"/>
+
+  <xs:element name="map-entry" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:sequence-constructor-and-select">
+          <xs:attribute name="key" type="xsl:expression"/>
+          <xs:attribute name="_key" type="xs:string"/>
+          <xs:assert test="exists(@key | @_key)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="matching-substring" type="xsl:sequence-constructor"/>
+
+  <xs:element name="merge" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:sequence>
+            <xs:element ref="xsl:merge-source" minOccurs="1" maxOccurs="unbounded"/>
+            <xs:element ref="xsl:merge-action" minOccurs="1" maxOccurs="1"/>
+            <xs:element ref="xsl:fallback" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="merge-action" type="xsl:sequence-constructor"/>
+
+  <xs:element name="merge-key" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:versioned-element-type">
+          <xs:sequence>
+            <xs:group ref="xsl:sequence-constructor-group"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+          </xs:sequence>
+          <xs:attribute name="select" type="xsl:expression"/>
+          <xs:attribute name="lang" type="xsl:avt"/>
+          <xs:attribute name="order" type="xsl:avt"/>
+          <xs:attribute name="collation" type="xs:anyURI"/>
+          <xs:attribute name="case-order" type="xsl:avt"/>
+          <xs:attribute name="data-type" type="xsl:avt"/>
+          <xs:attribute name="_select" type="xs:string"/>
+          <xs:attribute name="_lang" type="xs:string"/>
+          <xs:attribute name="_order" type="xs:string"/>
+          <xs:attribute name="_collation" type="xs:string"/>
+          <xs:attribute name="_case-order" type="xs:string"/>
+          <xs:attribute name="_data-type" type="xs:string"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="merge-source">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:sequence>
+            <xs:element ref="xsl:merge-key" minOccurs="1" maxOccurs="unbounded"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="xs:NCName"/>
+          <xs:attribute name="for-each-item" type="xsl:expression"/>
+          <xs:attribute name="for-each-source" type="xsl:expression"/>
+          <xs:attribute name="select" type="xsl:expression"/>
+          <xs:attribute name="streamable" type="xsl:yes-or-no"/>
+          <xs:attribute name="use-accumulators" type="xsl:accumulator-names"/>
+          <xs:attribute name="sort-before-merge" type="xsl:yes-or-no"/>
+          <xs:attribute name="type" type="xsl:EQName"/>
+          <xs:attribute name="validation" type="xsl:validation-type"/>
+          <xs:attribute name="_name" type="xs:string"/>
+          <xs:attribute name="_for-each-item" type="xs:string"/>
+          <xs:attribute name="_for-each-source" type="xs:string"/>
+          <xs:attribute name="_select" type="xs:string"/>
+          <xs:attribute name="_streamable" type="xs:string"/>
+          <xs:attribute name="_use-accumulators" type="xs:string"/>
+          <xs:attribute name="_sort-before-merge" type="xs:string"/>
+          <xs:attribute name="_type" type="xs:string"/>
+          <xs:attribute name="_validation" type="xs:string"/>
+          <xs:assert test="exists(@select | @_select)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="message" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:sequence-constructor">
+          <xs:attribute name="select" type="xsl:expression"/>
+          <xs:attribute name="terminate" type="xsl:avt" default="no"/>
+          <xs:attribute name="error-code" type="xsl:avt"/>
+          <xs:attribute name="_select" type="xs:string"/>
+          <xs:attribute name="_terminate" type="xs:string"/>
+          <xs:attribute name="_error-code" type="xs:string"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="mode" substitutionGroup="xsl:declaration">
+    <xs:complexType>
+      <xs:complexContent mixed="false">
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:attribute name="name" type="xsl:EQName"/>
+          <xs:attribute name="streamable" type="xsl:yes-or-no" default="no"/>
+          <xs:attribute name="use-accumulators" type="xsl:accumulator-names"/>
+          <xs:attribute name="on-no-match" type="xsl:on-no-match-type" default="shallow-skip"/>
+          <xs:attribute name="on-multiple-match"
+                        type="xsl:on-multiple-match-type"
+                        default="use-last"/>
+          <xs:attribute name="warning-on-no-match" type="xsl:yes-or-no"/>
+          <xs:attribute name="warning-on-multiple-match" type="xsl:yes-or-no"/>
+          <xs:attribute name="typed" type="xsl:typed-type"/>
+          <xs:attribute name="visibility">
+            <xs:simpleType>
+              <xs:restriction base="xsl:visibility-type">
+                <xs:enumeration value="public"/>
+                <xs:enumeration value="private"/>
+                <xs:enumeration value="final"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="_name" type="xs:string"/>
+          <xs:attribute name="_streamable" type="xs:string"/>
+          <xs:attribute name="_on-no-match" type="xs:string"/>
+          <xs:attribute name="_on-multiple-match" type="xs:string"/>
+          <xs:attribute name="_warning-on-no-match" type="xs:string"/>
+          <xs:attribute name="_warning-on-multiple-match" type="xs:string"/>
+          <xs:attribute name="_typed" type="xs:string"/>
+          <xs:attribute name="_visibility" type="xs:string"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+
+  <xs:element name="namespace" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:sequence-constructor-or-select">
+          <xs:attribute name="name" type="xsl:avt"/>
+          <xs:attribute name="_name" type="xs:string"/>
+          <xs:assert test="exists(@name | @_name)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="namespace-alias" substitutionGroup="xsl:declaration">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:attribute name="stylesheet-prefix" type="xsl:prefix-or-default"/>
+          <xs:attribute name="result-prefix" type="xsl:prefix-or-default"/>
+          <xs:attribute name="_stylesheet-prefix" type="xs:string"/>
+          <xs:attribute name="_result-prefix" type="xs:string"/>
+          <xs:assert test="exists(@stylesheet-prefix | @_stylesheet-prefix)"/>
+          <xs:assert test="exists(@result-prefix | @_result-prefix)"/>
+          <xs:assert test="every $prefix in (@stylesheet-prefix, @result-prefix)
+                                                /normalize-space(.)[. ne '#default']
+                           satisfies $prefix = in-scope-prefixes(.)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+
+  <xs:element name="next-iteration" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:sequence>
+            <xs:element ref="xsl:with-param" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+
+  <xs:element name="next-match" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="xsl:with-param"/>
+            <xs:element ref="xsl:fallback"/>
+          </xs:choice>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="non-matching-substring" type="xsl:sequence-constructor"/>
+
+  <xs:element name="number" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:versioned-element-type">
+          <xs:attribute name="value" type="xsl:expression"/>
+          <xs:attribute name="select" type="xsl:expression"/>
+          <xs:attribute name="level" type="xsl:level" default="single"/>
+          <xs:attribute name="count" type="xsl:pattern"/>
+          <xs:attribute name="from" type="xsl:pattern"/>
+          <xs:attribute name="format" type="xsl:avt" default="1"/>
+          <xs:attribute name="lang" type="xsl:avt"/>
+          <xs:attribute name="letter-value" type="xsl:avt"/>
+          <xs:attribute name="ordinal" type="xsl:avt"/>
+          <xs:attribute name="start-at" type="xsl:avt"/>
+          <xs:attribute name="grouping-separator" type="xsl:avt"/>
+          <xs:attribute name="grouping-size" type="xsl:avt"/>
+          <xs:attribute name="_value" type="xs:string"/>
+          <xs:attribute name="_select" type="xs:string"/>
+          <xs:attribute name="_level" type="xs:string"/>
+          <xs:attribute name="_count" type="xs:string"/>
+          <xs:attribute name="_from" type="xs:string"/>
+          <xs:attribute name="_format" type="xs:string"/>
+          <xs:attribute name="_lang" type="xs:string"/>
+          <xs:attribute name="_letter-value" type="xs:string"/>
+          <xs:attribute name="_ordinal" type="xs:string"/>
+          <xs:attribute name="_start-at" type="xs:string"/>
+          <xs:attribute name="_grouping-separator" type="xs:string"/>
+          <xs:attribute name="_grouping-size" type="xs:string"/>
+          <xs:assert test="if (exists(@value | @_value))
+                           then empty((@select | @_select, @count | @_count, @from | @_from))
+                            and (exists(@_level) or normalize-space(@level)='single')
+                           else true()">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  It is a static error if the value attribute of xsl:number is
+                  present unless the select, level, count, and from attributes are
+                  all absent.
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="on-completion" type="xsl:sequence-constructor-or-select"/>
+
+  <xs:element name="on-empty"
+              substitutionGroup="xsl:instruction"
+              type="xsl:sequence-constructor-or-select"/>
+
+  <xs:element name="on-non-empty"
+              substitutionGroup="xsl:instruction"
+              type="xsl:sequence-constructor-or-select"/>
+
+  <xs:element name="otherwise" type="xsl:sequence-constructor"/>
+
+  <xs:element name="output" substitutionGroup="xsl:declaration">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:generic-element-type">
+          <xs:attribute name="name" type="xsl:EQName"/>
+          <xs:attribute name="method" type="xsl:method"/>
+          <xs:attribute name="allow-duplicate-names" type="xsl:yes-or-no"/>
+          <xs:attribute name="build-tree" type="xsl:yes-or-no"/>
+          <xs:attribute name="byte-order-mark" type="xsl:yes-or-no"/>
+          <xs:attribute name="cdata-section-elements" type="xsl:EQNames"/>
+          <xs:attribute name="doctype-public" type="xs:string"/>
+          <xs:attribute name="doctype-system" type="xs:string"/>
+          <xs:attribute name="encoding" type="xs:string"/>
+          <xs:attribute name="escape-uri-attributes" type="xsl:yes-or-no"/>
+          <xs:attribute name="html-version" type="xs:decimal"/>
+          <xs:attribute name="include-content-type" type="xsl:yes-or-no"/>
+          <xs:attribute name="indent" type="xsl:yes-or-no"/>
+          <xs:attribute name="item-separator" type="xs:string"/>
+          <xs:attribute name="json-node-output-method" type="xsl:method"/>
+          <xs:attribute name="media-type" type="xs:string"/>
+          <xs:attribute name="normalization-form" type="xs:NMTOKEN"/>
+          <xs:attribute name="omit-xml-declaration" type="xsl:yes-or-no"/>
+          <xs:attribute name="parameter-document" type="xs:anyURI"/>
+          <xs:attribute name="standalone" type="xsl:yes-or-no-or-omit"/>
+          <xs:attribute name="suppress-indentation" type="xsl:EQNames"/>
+          <xs:attribute name="undeclare-prefixes" type="xsl:yes-or-no"/>
+          <xs:attribute name="use-character-maps" type="xsl:EQNames"/>
+          <xs:attribute name="version" type="xs:NMTOKEN"/>
+          <xs:attribute name="_name" type="xs:string"/>
+          <xs:attribute name="_method" type="xs:string"/>
+          <xs:attribute name="_byte-order-mark" type="xs:string"/>
+          <xs:attribute name="_cdata-section-elements" type="xs:string"/>
+          <xs:attribute name="_doctype-public" type="xs:string"/>
+          <xs:attribute name="_doctype-system" type="xs:string"/>
+          <xs:attribute name="_encoding" type="xs:string"/>
+          <xs:attribute name="_escape-uri-attributes" type="xs:string"/>
+          <xs:attribute name="_html-version" type="xs:string"/>
+          <xs:attribute name="_include-content-type" type="xs:string"/>
+          <xs:attribute name="_indent" type="xs:string"/>
+          <xs:attribute name="_item-separator" type="xs:string"/>
+          <xs:attribute name="_media-type" type="xs:string"/>
+          <xs:attribute name="_normalization-form" type="xs:string"/>
+          <xs:attribute name="_omit-xml-declaration" type="xs:string"/>
+          <xs:attribute name="_parameter-document" type="xs:string"/>
+          <xs:attribute name="_standalone" type="xs:string"/>
+          <xs:attribute name="_suppress-indentation" type="xs:string"/>
+          <xs:attribute name="_undeclare-prefixes" type="xs:string"/>
+          <xs:attribute name="_use-character-maps" type="xs:string"/>
+          <xs:attribute name="_version" type="xs:string"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="output-character">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:attribute name="character" type="xsl:char"/>
+          <xs:attribute name="string" type="xs:string"/>
+          <xs:attribute name="_character" type="xs:string"/>
+          <xs:attribute name="_string" type="xs:string"/>
+          <xs:assert test="exists(@character | @_character)"/>
+          <xs:assert test="exists(@string | @_string)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="override">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          This element appears as a child of xsl:use-package and defines any
+          overriding definitions of components that the containing package wishes
+          to make to the components made available from a library package.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="xsl:template"/>
+            <xs:element ref="xsl:function"/>
+            <xs:element ref="xsl:variable"/>
+            <xs:element ref="xsl:param"/>
+            <xs:element ref="xsl:attribute-set"/>
+          </xs:choice>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="package">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:element ref="xsl:expose"/>
+              <xs:element ref="xsl:declaration"/>
+              <xs:any namespace="##other" processContents="lax"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute name="declared-modes" type="xsl:yes-or-no"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="name" type="xs:anyURI"/>
+          <xs:attribute name="package-version" type="xs:string"/>
+          <xs:attribute name="input-type-annotations" type="xsl:input-type-annotations-type"/>
+          <xs:attribute name="_declared-modes" type="xs:string"/>
+          <xs:attribute name="_id" type="xs:string"/>
+          <xs:attribute name="_name" type="xs:string"/>
+          <xs:attribute name="_package-version" type="xs:string"/>
+          <xs:attribute name="_input-type-annotations" type="xs:string"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="param" substitutionGroup="xsl:declaration">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          Declaration of the xsl:param element, used both defining function
+          parameters, template parameters, parameters to xsl:iterate, and global
+          stylesheet parameters.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:sequence-constructor-or-select">
+          <xs:attribute name="name" type="xsl:EQName"/>
+          <xs:attribute name="as" type="xsl:sequence-type"/>
+          <xs:attribute name="required" type="xsl:yes-or-no"/>
+          <xs:attribute name="tunnel" type="xsl:yes-or-no"/>
+          <xs:attribute name="static" type="xsl:yes-or-no"/>
+          <xs:attribute name="_name" type="xs:string"/>
+          <xs:attribute name="_as" type="xs:string"/>
+          <xs:attribute name="_required" type="xs:string"/>
+          <xs:attribute name="_tunnel" type="xs:string"/>
+          <xs:attribute name="_static" type="xs:string"/>
+          <xs:assert test="exists(@name | @_name)"/>
+          <xs:assert test="if (normalize-space(@static) = ('yes', 'true', '1'))
+                           then empty((*,text()))
+                           else true()">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  When the attribute static="yes" is specified, the xsl:param
+                  element must have empty content.
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+
+
+  <xs:element name="perform-sort" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:versioned-element-type">
+          <xs:sequence>
+            <xs:element ref="xsl:sort" minOccurs="1" maxOccurs="unbounded"/>
+            <xs:group ref="xsl:sequence-constructor-group"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+          </xs:sequence>
+          <xs:attribute name="select" type="xsl:expression"/>
+          <xs:assert test="every $e in subsequence(xsl:sort, 2)
+                           satisfies empty($e/(@stable | @_stable))">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  It is a static error if an xsl:sort element other than the first
+                  in a sequence of sibling xsl:sort elements has a stable
+                  attribute.
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="preserve-space" substitutionGroup="xsl:declaration">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:attribute name="elements" type="xsl:nametests"/>
+          <xs:attribute name="_elements" type="xs:string"/>
+          <xs:assert test="exists(@elements | @_elements)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="processing-instruction" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:sequence-constructor-or-select">
+          <xs:attribute name="name" type="xsl:avt"/>
+          <xs:attribute name="_name" type="xs:string"/>
+          <xs:assert test="exists(@name | @_name)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="result-document" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:sequence-constructor">
+          <xs:attribute name="format" type="xsl:avt"/>
+          <xs:attribute name="href" type="xsl:avt"/>
+          <xs:attribute name="type" type="xsl:EQName"/>
+          <xs:attribute name="validation" type="xsl:validation-type"/>
+          <xs:attribute name="method" type="xsl:avt"/>
+          <xs:attribute name="allow-duplicate-names" type="xsl:avt"/>
+          <xs:attribute name="build-tree" type="xsl:avt"/>
+          <xs:attribute name="byte-order-mark" type="xsl:avt"/>
+          <xs:attribute name="cdata-section-elements" type="xsl:avt"/>
+          <xs:attribute name="doctype-public" type="xsl:avt"/>
+          <xs:attribute name="doctype-system" type="xsl:avt"/>
+          <xs:attribute name="encoding" type="xsl:avt"/>
+          <xs:attribute name="escape-uri-attributes" type="xsl:avt"/>
+          <xs:attribute name="html-version" type="xsl:avt"/>
+          <xs:attribute name="include-content-type" type="xsl:avt"/>
+          <xs:attribute name="indent" type="xsl:avt"/>
+          <xs:attribute name="item-separator" type="xsl:avt"/>
+          <xs:attribute name="json-node-output-method" type="xsl:avt"/>
+          <xs:attribute name="media-type" type="xsl:avt"/>
+          <xs:attribute name="normalization-form" type="xsl:avt"/>
+          <xs:attribute name="omit-xml-declaration" type="xsl:avt"/>
+          <xs:attribute name="parameter-document" type="xsl:avt"/>
+          <xs:attribute name="standalone" type="xsl:avt"/>
+          <xs:attribute name="suppress-indentation" type="xsl:avt"/>
+          <xs:attribute name="undeclare-prefixes" type="xsl:avt"/>
+          <xs:attribute name="use-character-maps" type="xsl:EQNames"/>
+          <xs:attribute name="output-version" type="xsl:avt"/>
+          <xs:attribute name="_format" type="xs:string"/>
+          <xs:attribute name="_href" type="xs:string"/>
+          <xs:attribute name="_type" type="xs:string"/>
+          <xs:attribute name="_validation" type="xs:string"/>
+          <xs:attribute name="_method" type="xs:string"/>
+          <xs:attribute name="_byte-order-mark" type="xs:string"/>
+          <xs:attribute name="_cdata-section-elements" type="xs:string"/>
+          <xs:attribute name="_doctype-public" type="xs:string"/>
+          <xs:attribute name="_doctype-system" type="xs:string"/>
+          <xs:attribute name="_encoding" type="xs:string"/>
+          <xs:attribute name="_escape-uri-attributes" type="xs:string"/>
+          <xs:attribute name="_html-version" type="xs:string"/>
+          <xs:attribute name="_include-content-type" type="xs:string"/>
+          <xs:attribute name="_indent" type="xs:string"/>
+          <xs:attribute name="_item-separator" type="xs:string"/>
+          <xs:attribute name="_media-type" type="xs:string"/>
+          <xs:attribute name="_normalization-form" type="xs:string"/>
+          <xs:attribute name="_omit-xml-declaration" type="xs:string"/>
+          <xs:attribute name="_parameter-document" type="xs:string"/>
+          <xs:attribute name="_standalone" type="xs:string"/>
+          <xs:attribute name="_suppress-indentation" type="xs:string"/>
+          <xs:attribute name="_undeclare-prefixes" type="xs:string"/>
+          <xs:attribute name="_use-character-maps" type="xs:string"/>
+          <xs:attribute name="_output-version" type="xs:string"/>
+          <xs:assert test="not(exists(@type | @_type) and exists(@validation | @_validation))">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  The type and validation attributes are mutually exclusive (if
+                  one is present, the other must be absent).
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="sequence"
+              substitutionGroup="xsl:instruction"
+              type="xsl:sequence-constructor-or-select"/>
+
+  <xs:element name="sort">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:sequence-constructor-or-select">
+          <xs:attribute name="lang" type="xsl:avt"/>
+          <xs:attribute name="data-type" type="xsl:avt" default="text"/>
+          <xs:attribute name="order" type="xsl:avt" default="ascending"/>
+          <xs:attribute name="case-order" type="xsl:avt"/>
+          <xs:attribute name="collation" type="xsl:avt"/>
+          <xs:attribute name="stable" type="xsl:avt"/>
+          <xs:attribute name="_lang" type="xs:string"/>
+          <xs:attribute name="_data-type" type="xs:string"/>
+          <xs:attribute name="_order" type="xs:string"/>
+          <xs:attribute name="_case-order" type="xs:string"/>
+          <xs:attribute name="_collation" type="xs:string"/>
+          <xs:attribute name="_stable" type="xs:string"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="source-document" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:sequence-constructor">
+          <xs:attribute name="href" type="xsl:avt"/>
+          <xs:attribute name="streamable" type="xsl:yes-or-no" default="no"/>
+          <xs:attribute name="use-accumulators" type="xsl:accumulator-names"/>
+          <xs:attribute name="type" type="xsl:EQName"/>
+          <xs:attribute name="validation" type="xsl:validation-type"/>
+          <xs:attribute name="_href" type="xs:string"/>
+          <xs:attribute name="_streamable" type="xs:string"/>
+          <xs:attribute name="_use-accumulators" type="xs:string"/>
+          <xs:attribute name="_type" type="xs:string"/>
+          <xs:attribute name="_validation" type="xs:string"/>
+          <xs:assert test="exists(@href | @_href)"/>
+          <xs:assert test="not(exists(@type | @_type) and exists(@validation | @_validation))">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  The type and validation attributes are mutually exclusive (if
+                  one is present, the other must be absent).
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="strip-space" substitutionGroup="xsl:declaration">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:attribute name="elements" type="xsl:nametests"/>
+          <xs:attribute name="_elements" type="xs:string"/>
+          <xs:assert test="exists(@elements | @_elements)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="stylesheet" substitutionGroup="xsl:transform"/>
+
+
+  <xs:element name="template" substitutionGroup="xsl:declaration">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:versioned-element-type">
+          <xs:sequence>
+            <xs:element ref="xsl:context-item" minOccurs="0" maxOccurs="1"/>
+            <xs:element ref="xsl:param" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:group ref="xsl:sequence-constructor-group"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+          </xs:sequence>
+          <xs:attribute name="match" type="xsl:pattern"/>
+          <xs:attribute name="priority" type="xs:decimal"/>
+          <xs:attribute name="mode" type="xsl:modes"/>
+          <xs:attribute name="name" type="xsl:EQName"/>
+          <xs:attribute name="as" type="xsl:sequence-type" default="item()*"/>
+          <xs:attribute name="visibility" type="xsl:visibility-type"/>
+          <xs:attribute name="_match" type="xs:string"/>
+          <xs:attribute name="_priority" type="xs:string"/>
+          <xs:attribute name="_mode" type="xs:string"/>
+          <xs:attribute name="_name" type="xs:string"/>
+          <xs:attribute name="_as" type="xs:string"/>
+          <xs:attribute name="_visibility" type="xs:string"/>
+          <xs:assert test="exists(@match | @_match) or exists(@name | @_name)">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  An xsl:template element must have either a match attribute or a
+                  name attribute, or both.
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+          <xs:assert test="if (empty(@match | @_match))
+                           then (empty(@mode | @_mode) and empty(@priority | @_priority))
+                           else true()">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  An xsl:template element that has no match attribute must have no
+                  mode attribute and no priority attribute.
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+          <xs:assert test="not(exists(@visibility | @_visibility) and empty(@name | @_name))">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  An xsl:template element that has no name attribute must have no
+                  visibility attribute
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+          <xs:assert test="if (normalize-space(@visibility) = 'abstract')
+                           then empty(* except (xsl:context-item, xsl:param))
+                           else true()">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  If the visibility attribute is present with the value abstract
+                  then (a) the sequence constructor defining the template body
+                  must be empty: that is, the only permitted children are
+                  xsl:context-item and xsl:param
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+          <xs:assert test="not(normalize-space(@visibility) = 'abstract' and exists(@match))">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  If the visibility attribute is present with the value abstract
+                  then there must be no match attribute.
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+          <xs:assert test="every $e in xsl:param satisfies empty($e/(@visibility | @_visibility))">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  A parameter for a template must have no visibility attribute.
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:complexType name="text-element-base-type">
+    <xs:simpleContent>
+      <xs:restriction base="xsl:versioned-element-type">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="text-element-type">
+    <xs:simpleContent>
+      <xs:extension base="xsl:text-element-base-type">
+        <xs:attribute name="disable-output-escaping" type="xsl:yes-or-no" default="no"/>
+        <xs:attribute name="_disable-output-escaping" type="xs:string"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="text"
+              substitutionGroup="xsl:instruction"
+              type="xsl:text-element-type"/>
+
+
+  <xs:complexType name="transform-element-base-type">
+    <xs:complexContent>
+      <xs:restriction base="xsl:element-only-versioned-element-type">
+        <xs:attribute name="version" type="xs:decimal" use="optional"/>
+        <xs:attribute name="_version" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>
+              <p>
+                The version attribute indicates the version of XSLT that the
+                stylesheet module requires. The attribute is required, unless the
+                xsl:stylesheet element is a child of an xsl:package element, in
+                which case it is optional: the default is then taken from the
+                parent xsl:package element.
+              </p>
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:element name="transform">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:transform-element-base-type">
+          <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:element ref="xsl:declaration"/>
+              <xs:any namespace="##other" processContents="lax"/>
+              <!-- weaker than XSLT 1.0 -->
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="input-type-annotations"
+                        type="xsl:input-type-annotations-type"
+                        default="unspecified"/>
+          <xs:attribute name="_id" type="xs:string"/>
+          <xs:attribute name="_input-type-annotations" type="xs:string"/>
+          <!--* The 'static' attribute may be used on 'param' and 'variable'
+              * only when they are top-level elements. *-->
+          <xs:assert test="every $v in (.//xsl:param, .//xsl:variable)[exists(@static | @_static)]
+                           satisfies $v[parent::xsl:stylesheet or parent::xsl:transform or parent::xsl:override]">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  The static attribute must not be present on an xsl:variable or
+                  xsl:param element unless it is a top-level element.
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+          <xs:assert test="every $prefix in (@exclude-result-prefixes[not(. = '#all')],
+                                             @extension-element-prefixes)
+                           satisfies ((if ($prefix = '#default') then '' else $prefix) = in-scope-prefixes(.))">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  XTSE0808: It is a static error if a namespace prefix is used
+                  within the [xsl:]exclude-result-prefixes attribute and there is
+                  no namespace binding in scope for that prefix.
+                </p>
+                <p>
+                  XTSE0809: It is a static error if the value #default is used
+                  within the [xsl:]exclude-result-prefixes attribute and the
+                  parent element of the [xsl:]exclude-result-prefixes attribute
+                  has no default namespace.
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="try" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:versioned-element-type">
+          <xs:sequence>
+            <xs:group ref="xsl:sequence-constructor-group"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+            <xs:element ref="xsl:catch" minOccurs="1" maxOccurs="1"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:element ref="xsl:catch"/>
+              <xs:element ref="xsl:fallback"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute name="rollback-output" type="xsl:yes-or-no" default="yes"/>
+          <xs:attribute name="select" type="xsl:expression" use="optional"/>
+          <xs:attribute name="_rollback-output" type="xs:string"/>
+          <xs:attribute name="_select" type="xs:string"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="use-package" substitutionGroup="xsl:declaration">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          This element appears as a child of xsl:package and defines a dependency
+          of the containing package on another package, identified by URI in the
+          name attribute. The package-version attribute indicates which version of
+          the library package is required, or may indicate a range of versions.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent mixed="false">
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="xsl:accept"/>
+            <xs:element ref="xsl:override"/>
+          </xs:choice>
+          <xs:attribute name="name" type="xs:anyURI"/>
+          <xs:attribute name="package-version" type="xs:string"/>
+          <xs:attribute name="_name" type="xs:string"/>
+          <xs:attribute name="_package-version" type="xs:string"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="value-of" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:sequence-constructor-or-select">
+          <xs:attribute name="separator" type="xsl:avt"/>
+          <xs:attribute name="disable-output-escaping" type="xsl:yes-or-no" default="no"/>
+          <xs:attribute name="_separator" type="xs:string"/>
+          <xs:attribute name="_disable-output-escaping" type="xs:string"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="variable" substitutionGroup="xsl:declaration xsl:instruction">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          Declaration of the xsl:variable element, used both for local and global
+          variable bindings.
+        </p>
+        <p>
+          This definition takes advantage of the ability in XSD 1.1 for an element
+          to belong to more than one substitution group. A global variable is a
+          declaration, while a local variable can appear as an instruction in a
+          sequence constructor.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:sequence-constructor-or-select">
+          <xs:attribute name="name" type="xsl:EQName"/>
+          <xs:attribute name="as" type="xsl:sequence-type"/>
+          <xs:attribute name="visibility" type="xsl:visibility-type"/>
+          <xs:attribute name="static" type="xsl:yes-or-no"/>
+          <xs:attribute name="_name" type="xs:string"/>
+          <xs:attribute name="_as" type="xs:string"/>
+          <xs:attribute name="_visibility" type="xs:string"/>
+          <xs:attribute name="_static" type="xs:string"/>
+          <xs:assert test="exists(@name | @_name)"/>
+          <xs:assert test="if (normalize-space(@static) = ('yes', 'true', '1'))
+                           then (exists(@_visibility) or normalize-space(@visibility)
+                                       = ('', 'private', 'final'))
+                           else true()">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  When the static attribute is present with the value yes, the
+                  visibility attribute must not have a value other than private or
+                  final.
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+          <xs:assert test="if (normalize-space(@static) = ('yes', 'true', '1'))
+                           then (empty((*, text())) and exists(@select | @_select))
+                           else true()">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  When the attribute static="yes" is specified, the xsl:variable
+                  element must have empty content, and the select attribute must
+                  be present to define the value of the variable.
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="when">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:sequence-constructor">
+          <xs:attribute name="test" type="xsl:expression"/>
+          <xs:attribute name="_test" type="xs:string"/>
+          <xs:assert test="exists(@test | @_test)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="where-populated"
+              substitutionGroup="xsl:instruction"
+              type="xsl:sequence-constructor"/>
+
+  <xs:element name="with-param">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:sequence-constructor-or-select">
+          <xs:attribute name="name" type="xsl:EQName"/>
+          <xs:attribute name="as" type="xsl:sequence-type"/>
+          <xs:attribute name="tunnel" type="xsl:yes-or-no"/>
+          <xs:attribute name="_name" type="xs:string"/>
+          <xs:attribute name="_as" type="xs:string"/>
+          <xs:attribute name="_tunnel" type="xs:string"/>
+          <xs:assert test="exists(@name | @_name)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:annotation>
+    <xs:documentation>
+      <p>
+        PART C: definition of literal result elements There are three ways to
+        define the literal result elements permissible in a stylesheet. (a) do
+        nothing. This allows any element to be used as a literal result element,
+        provided it is not in the XSLT namespace (b) declare all permitted literal
+        result elements as members of the xsl:literal-result-element substitution
+        group (c) redefine the model group xsl:result-elements to accommodate all
+        permitted literal result elements. Literal result elements are allowed to
+        take certain attributes in the XSLT namespace. These are defined in the
+        attribute group literal-result-element-attributes, which can be included
+        in the definition of any literal result element.
+      </p>
+    </xs:documentation>
+  </xs:annotation>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <xs:element name="literal-result-element" abstract="true" type="xs:anyType"/>
+
+  <xs:attributeGroup name="literal-result-element-attributes">
+    <xs:attribute name="default-collation" form="qualified" type="xsl:uri-list"/>
+    <xs:attribute name="default-mode" type="xsl:default-mode-type"/>
+    <xs:attribute name="default-validation"
+                  type="xsl:validation-strip-or-preserve"
+                  default="strip"/>
+    <xs:attribute name="expand-text" type="xsl:yes-or-no"/>
+    <xs:attribute name="extension-element-prefixes" form="qualified" type="xsl:prefixes"/>
+    <xs:attribute name="exclude-result-prefixes" form="qualified" type="xsl:prefixes"/>
+    <xs:attribute name="xpath-default-namespace" form="qualified" type="xs:anyURI"/>
+    <xs:attribute name="inherit-namespaces"
+                  form="qualified"
+                  type="xsl:yes-or-no"
+                  default="yes"/>
+    <xs:attribute name="use-attribute-sets"
+                  form="qualified"
+                  type="xsl:EQNames"
+                  default=""/>
+    <xs:attribute name="use-when" form="qualified" type="xsl:expression"/>
+    <xs:attribute name="version" form="qualified" type="xs:decimal"/>
+    <xs:attribute name="type" form="qualified" type="xsl:EQName"/>
+    <xs:attribute name="validation" form="qualified" type="xsl:validation-type"/>
+  </xs:attributeGroup>
+
+  <xs:group name="result-elements">
+    <xs:choice>
+      <xs:element ref="xsl:literal-result-element"/>
+      <xs:any namespace="##other" processContents="lax"/>
+      <xs:any namespace="##local" processContents="lax"/>
+    </xs:choice>
+  </xs:group>
+
+
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:annotation>
+    <xs:documentation>
+      <p>
+        PART D: definitions of simple types used in stylesheet attributes
+      </p>
+    </xs:documentation>
+  </xs:annotation>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <xs:simpleType name="accumulator-names">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          The use-accumulators attribute of xsl:source-document, xsl:merge-source,
+          or xsl:global-context-item: either a list, each member being a QName; or
+          the value #all
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union>
+      <xs:simpleType>
+        <xs:list itemType="xsl:EQName"/>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="#all"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+
+  <xs:simpleType name="avt">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          This type is used for all attributes that allow an attribute value
+          template. The general rules for the syntax of attribute value templates,
+          and the specific rules for each such attribute, are described in the
+          XSLT 2.1 Recommendation.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="char">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          A string containing exactly one character.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:length value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="component-kind-type">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          Describes a kind of component within a package.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="template"/>
+      <xs:enumeration value="function"/>
+      <xs:enumeration value="variable"/>
+      <xs:enumeration value="attribute-set"/>
+      <xs:enumeration value="mode"/>
+      <xs:enumeration value="*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="default-mode-type">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          The default-mode attribute of xsl:stylesheet, xsl:transform, xsl:package
+          (or any other xsl:* element): either a QName or #unnamed.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="xsl:EQName">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="#unnamed"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+
+  <xs:simpleType name="expression">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          An XPath 2.0 expression.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:pattern value=".+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="item-type">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          An XPath 2.1 ItemType
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:pattern value=".+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="input-type-annotations-type">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          Describes how type annotations in source documents are handled.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="preserve"/>
+      <xs:enumeration value="strip"/>
+      <xs:enumeration value="unspecified"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="level">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          The level attribute of xsl:number: one of single, multiple, or any.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="single"/>
+      <xs:enumeration value="multiple"/>
+      <xs:enumeration value="any"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="mode">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          The mode attribute of xsl:apply-templates: either a QName, or #current,
+          or #unnamed, or #default.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="xsl:EQName">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="#default"/>
+          <xs:enumeration value="#unnamed"/>
+          <xs:enumeration value="#current"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+
+  <xs:simpleType name="modes">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          The mode attribute of xsl:template: either a list, each member being
+          either a QName or #default or #unnamed; or the value #all
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union>
+      <xs:simpleType>
+        <xs:restriction>
+          <xs:simpleType>
+            <xs:list>
+              <xs:simpleType>
+                <xs:union memberTypes="xsl:EQName">
+                  <xs:simpleType>
+                    <xs:restriction base="xs:token">
+                      <xs:enumeration value="#default"/>
+                      <xs:enumeration value="#unnamed"/>
+                    </xs:restriction>
+                  </xs:simpleType>
+                </xs:union>
+              </xs:simpleType>
+            </xs:list>
+          </xs:simpleType>
+          <xs:assertion test="count($value) = count(distinct-values($value))">
+            <xs:annotation>
+              <xs:documentation>
+                <p>
+                  XTSE0550: It is a static error if the same token is included
+                  more than once in the list.
+                </p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assertion>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="#all"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+
+  <xs:simpleType name="nametests">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          A list of NameTests, as defined in the XPath 2.0 Recommendation. Each
+          NameTest is either a QName, or "*", or "prefix:*", or "*:localname"
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:list>
+      <xs:simpleType>
+        <xs:union memberTypes="xsl:EQName">
+          <xs:simpleType>
+            <xs:restriction base="xs:token">
+              <xs:enumeration value="*"/>
+            </xs:restriction>
+          </xs:simpleType>
+          <xs:simpleType>
+            <xs:restriction base="xs:token">
+              <xs:pattern value="\i\c*:\*"/>
+              <xs:pattern value="\*:\i\c*"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:union>
+      </xs:simpleType>
+    </xs:list>
+  </xs:simpleType>
+
+  <xs:simpleType name="on-multiple-match-type">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          Describes the action to be taken when there are several template rules
+          to match an item in a given mode.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="use-last"/>
+      <xs:enumeration value="fail"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="on-no-match-type">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          Describes the action to be taken when there is no template rule to match
+          an item in a given mode.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="deep-copy"/>
+      <xs:enumeration value="shallow-copy"/>
+      <xs:enumeration value="deep-skip"/>
+      <xs:enumeration value="shallow-skip"/>
+      <xs:enumeration value="text-only-copy"/>
+      <xs:enumeration value="fail"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="prefixes">
+    <xs:list itemType="xs:NCName"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="prefix-list-or-all">
+    <xs:union memberTypes="xsl:prefix-list">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="#all"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+
+  <xs:simpleType name="prefix-list">
+    <xs:list itemType="xsl:prefix-or-default"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="method">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          The method attribute of xsl:output: Either one of the recognized names
+          "xml", "xhtml", "html", "text", or a QName that must include a prefix.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="xml"/>
+          <xs:enumeration value="xhtml"/>
+          <xs:enumeration value="html"/>
+          <xs:enumeration value="text"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xsl:EQName">
+          <xs:pattern value="\c*:\c*"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+
+  <xs:simpleType name="pattern">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          A match pattern as defined in the XSLT 2.1 Recommendation. The syntax
+          for patterns is a restricted form of the syntax for XPath 2.0
+          expressions. Change since XSLT 2.0: Patterns may now match any item (not
+          only nodes)
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xsl:expression"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="prefix-or-default">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          Either a namespace prefix, or #default. Used in the xsl:namespace-alias
+          element.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="xs:NCName">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="#default"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+
+  <xs:simpleType name="EQNames">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          A list of QNames. Used in the [xsl:]use-attribute-sets attribute of
+          various elements, and in the cdata-section-elements attribute of
+          xsl:output
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:list itemType="xsl:EQName"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="EQName">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          An extended QName. This schema does not use the built-in type xs:QName,
+          but rather defines its own QName type. This may be either a local name,
+          or a prefixed QName, or a name written using the extended QName notation
+          Q{uri}local
+        </p>
+        <p>
+          Although xs:QName would define the correct validation on these
+          attributes, a schema processor would expand unprefixed QNames
+          incorrectly when constructing the PSVI, because (as defined in XML
+          Schema errata) an unprefixed xs:QName is assumed to be in the default
+          namespace, which is not the correct assumption for XSLT. The datatype is
+          therefore defined as a union of NCName and QName, so that an unprefixed
+          name will be validated as an NCName and will therefore not be treated as
+          having the semantics of an unprefixed xs:QName.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="xs:NCName xs:QName">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:pattern value="Q\{[^{}]*\}[\i-[:]][\c-[:]]*"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+
+  <xs:simpleType name="EQName-in-namespace">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          A subtype of EQNames that excludes no-namespace names
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xsl:EQName">
+      <xs:pattern value="Q\{.+\}.+|\i\c*:.+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="sequence-type">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          The description of a datatype, conforming to the SequenceType production
+          defined in the XPath 2.0 Recommendation
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:pattern value=".+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="streamability-type">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          Describes the category to which a function belongs, with regards to its
+          streaming behavior.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="xsl:EQName-in-namespace">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="unclassified"/>
+          <xs:enumeration value="absorbing"/>
+          <xs:enumeration value="inspection"/>
+          <xs:enumeration value="filter"/>
+          <xs:enumeration value="shallow-descent"/>
+          <xs:enumeration value="deep-descent"/>
+          <xs:enumeration value="ascent"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+
+  <xs:simpleType name="typed-type">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          Describes whether a mode is designed to match typed or untyped nodes.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="yes"/>
+      <xs:enumeration value="no"/>
+      <xs:enumeration value="true"/>
+      <xs:enumeration value="false"/>
+      <xs:enumeration value="1"/>
+      <xs:enumeration value="0"/>
+      <xs:enumeration value="strict"/>
+      <xs:enumeration value="lax"/>
+      <xs:enumeration value="unspecified"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="uri-list">
+    <xs:list itemType="xs:anyURI"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="validation-strip-or-preserve">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          Describes different ways of type-annotating an element or attribute.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xsl:validation-type">
+      <xs:enumeration value="preserve"/>
+      <xs:enumeration value="strip"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="validation-type">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          Describes different ways of type-annotating an element or attribute.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="strict"/>
+      <xs:enumeration value="lax"/>
+      <xs:enumeration value="preserve"/>
+      <xs:enumeration value="strip"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="visibility-type">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          Describes the visibility of a component within a package.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="public"/>
+      <xs:enumeration value="private"/>
+      <xs:enumeration value="final"/>
+      <xs:enumeration value="abstract"/>
+      <xs:enumeration value="hidden"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="visibility-not-hidden-type">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          Describes the visibility of a component within a package.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xsl:visibility-type">
+      <xs:enumeration value="public"/>
+      <xs:enumeration value="private"/>
+      <xs:enumeration value="final"/>
+      <xs:enumeration value="abstract"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="yes-or-no">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          One of the values "yes" or "no": the values "true" or "false", or "1" or
+          "0" are accepted as synonyms.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="yes"/>
+      <xs:enumeration value="no"/>
+      <xs:enumeration value="true"/>
+      <xs:enumeration value="false"/>
+      <xs:enumeration value="1"/>
+      <xs:enumeration value="0"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="yes-or-no-or-maybe">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          One of the values "yes" or "no" or "omit". The values "true" or "false",
+          or "1" or "0" are accepted as synonyms of "yes" and "no" respectively.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="yes"/>
+      <xs:enumeration value="no"/>
+      <xs:enumeration value="true"/>
+      <xs:enumeration value="false"/>
+      <xs:enumeration value="1"/>
+      <xs:enumeration value="0"/>
+      <xs:enumeration value="maybe"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="yes-or-no-or-omit">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          One of the values "yes" or "no" or "omit". The values "true" or "false",
+          or "1" or "0" are accepted as synonyms of "yes" and "no" respectively.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="yes"/>
+      <xs:enumeration value="no"/>
+      <xs:enumeration value="true"/>
+      <xs:enumeration value="false"/>
+      <xs:enumeration value="1"/>
+      <xs:enumeration value="0"/>
+      <xs:enumeration value="omit"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="zero-digit">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          A digit that has the numerical value zero.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xsl:char">
+      <xs:pattern value="\p{Nd}"/>
+      <xs:assertion test="matches(string-join(codepoints-to-string(
+           for $i in 0 to 9 return string-to-codepoints($value) + $i), ''), '\p{Nd}{10}')"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+</xs:schema>

--- a/xml/xml-psi-impl/src/com/intellij/javaee/InternalResourceProvider.java
+++ b/xml/xml-psi-impl/src/com/intellij/javaee/InternalResourceProvider.java
@@ -29,12 +29,14 @@ public class InternalResourceProvider implements StandardResourceProvider{
 
     impl.addInternalResource(XmlUtil.XSLT_URI,"xslt-1_0.xsd");
     impl.addInternalResource(XmlUtil.XSLT_URI,"2.0", "xslt-2_0.xsd");
+    impl.addInternalResource(XmlUtil.XSLT_URI,"3.0", "xslt-3_0.xsd");
     impl.addInternalResource(XmlUtil.XINCLUDE_URI,"xinclude.xsd");
 
     impl.addInternalResource(XmlUtil.XML_SCHEMA_URI, "XMLSchema.xsd");
     impl.addInternalResource(XmlUtil.XML_SCHEMA_URI + ".xsd", "XMLSchema.xsd");
 
     impl.addInternalResource("http://www.w3.org/2001/XMLSchema.dtd", "XMLSchema.dtd");
+    impl.addInternalResource("http://www.w3.org/TR/xmlschema11-1/XMLSchema.xsd", "XMLSchema-1_1/XMLSchema.dtd");
     impl.addInternalResource(XmlUtil.XML_SCHEMA_INSTANCE_URI, "XMLSchema-instance.xsd");
     impl.addInternalResource(XmlUtil.XML_SCHEMA_VERSIONING_URI, "XMLSchema-versioning.xsd");
     impl.addInternalResource("http://www.w3.org/2001/xml.xsd","xml.xsd");

--- a/xml/xml-psi-impl/src/com/intellij/javaee/InternalResourceProvider.java
+++ b/xml/xml-psi-impl/src/com/intellij/javaee/InternalResourceProvider.java
@@ -36,7 +36,7 @@ public class InternalResourceProvider implements StandardResourceProvider{
     impl.addInternalResource(XmlUtil.XML_SCHEMA_URI + ".xsd", "XMLSchema.xsd");
 
     impl.addInternalResource("http://www.w3.org/2001/XMLSchema.dtd", "XMLSchema.dtd");
-    impl.addInternalResource("http://www.w3.org/TR/xmlschema11-1/XMLSchema.xsd", "XMLSchema-1_1/XMLSchema.dtd");
+    impl.addInternalResource("http://www.w3.org/TR/xmlschema11-1/XMLSchema.xsd", "XMLSchema-1_1/XMLSchema.xsd");
     impl.addInternalResource(XmlUtil.XML_SCHEMA_INSTANCE_URI, "XMLSchema-instance.xsd");
     impl.addInternalResource(XmlUtil.XML_SCHEMA_VERSIONING_URI, "XMLSchema-versioning.xsd");
     impl.addInternalResource("http://www.w3.org/2001/xml.xsd","xml.xsd");


### PR DESCRIPTION
While XSLT 3.0 offers much more functionality, the basic thing you want is that the IDE at least recognizes the same functionality as in 2.0. I think with these simple changes that should be fixed. Since I am not a Java developer, and also did not test this, you should take this PR with care.
 See PR 599 in origin repo