### PR TITLE
IDEA-146390 Modules generated from Maven sources named using artifact name

### DIFF
--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/importing/MavenProjectImporter.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/importing/MavenProjectImporter.java
@@ -36,7 +36,6 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.ArrayUtil;
-import com.intellij.util.Function;
 import com.intellij.util.containers.Stack;
 import gnu.trove.THashMap;
 import gnu.trove.THashSet;
@@ -407,7 +406,8 @@ public class MavenProjectImporter {
                               myMavenProjectToModule,
                               myMavenProjectToModuleName,
                               myMavenProjectToModulePath,
-                              myImportingSettings.getDedicatedModuleDir());
+                              myImportingSettings.getDedicatedModuleDir(),
+                              myImportingSettings.isPreferArtifactName());
   }
 
   private void removeOutdatedCompilerConfigSettings() {

--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/project/MavenImportingSettings.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/project/MavenImportingSettings.java
@@ -46,6 +46,7 @@ public class MavenImportingSettings implements Cloneable {
   private boolean excludeTargetFolder = true;
   private boolean keepSourceFolders = true;
   private boolean useMavenOutput = true;
+  private boolean preferArtifactName = false;
   private String updateFoldersOnImportPhase = UPDATE_FOLDERS_DEFAULT_PHASE;
 
   private boolean downloadSourcesAutomatically = false;
@@ -163,6 +164,14 @@ public class MavenImportingSettings implements Cloneable {
     this.useMavenOutput = useMavenOutput;
   }
 
+  public boolean isPreferArtifactName() {
+    return preferArtifactName;
+  }
+
+  public void setPreferArtifactName(boolean preferArtifactName) {
+    this.preferArtifactName = preferArtifactName;
+  }
+
   public String getUpdateFoldersOnImportPhase() {
     return updateFoldersOnImportPhase;
   }
@@ -208,6 +217,7 @@ public class MavenImportingSettings implements Cloneable {
 
     if (createModuleGroups != that.createModuleGroups) return false;
     if (createModulesForAggregators != that.createModulesForAggregators) return false;
+    if (preferArtifactName != that.preferArtifactName) return false;
     if (importAutomatically != that.importAutomatically) return false;
     if (!dependencyTypes.equals(that.dependencyTypes)) return false;
     if (downloadDocsAutomatically != that.downloadDocsAutomatically) return false;
@@ -236,6 +246,8 @@ public class MavenImportingSettings implements Cloneable {
     if (importAutomatically) result++;
     result <<= 1;
     if (createModulesForAggregators) result++;
+    result <<= 1;
+    if (preferArtifactName) result++;
     result <<= 1;
     if (createModuleGroups) result++;
     result <<= 1;

--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/project/MavenImportingSettingsForm.form
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/project/MavenImportingSettingsForm.form
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.jetbrains.idea.maven.project.MavenImportingSettingsForm">
-  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="19" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="20" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="769" height="577"/>
+      <xy x="20" y="20" width="1362" height="1021"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -34,7 +34,7 @@
       </component>
       <component id="1b499" class="javax.swing.JCheckBox" binding="myUseMavenOutputCheckBox">
         <constraints>
-          <grid row="9" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="10" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Use Maven &amp;output directories"/>
@@ -43,7 +43,7 @@
       </component>
       <component id="22b1c" class="com.intellij.ui.components.JBLabel">
         <constraints>
-          <grid row="13" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="3" use-parent-layout="false"/>
+          <grid row="14" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="3" use-parent-layout="false"/>
         </constraints>
         <properties>
           <componentStyle value="SMALL"/>
@@ -63,7 +63,7 @@
       <grid id="49dc8" layout-manager="GridLayoutManager" row-count="1" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="10" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="14" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="15" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <focusable value="true"/>
@@ -103,7 +103,7 @@
       </grid>
       <component id="6d280" class="javax.swing.JCheckBox" binding="myKeepSourceFoldersCheckBox">
         <constraints>
-          <grid row="7" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="8" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Keep source and test &amp;folders on reimport"/>
@@ -112,7 +112,7 @@
       <grid id="d7645" binding="myAdditionalSettingsPanel" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="15" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="17" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="8" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="18" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="8" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -120,7 +120,7 @@
       </grid>
       <hspacer id="d45a7">
         <constraints>
-          <grid row="14" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="15" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
       </hspacer>
       <grid id="eca06" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
@@ -181,13 +181,13 @@
       </grid>
       <vspacer id="5d738">
         <constraints>
-          <grid row="18" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="19" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <grid id="34bc4" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="12" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="13" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -216,7 +216,7 @@
       </grid>
       <vspacer id="aa40b">
         <constraints>
-          <grid row="11" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+          <grid row="12" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
             <preferred-size width="-1" height="10"/>
           </grid>
         </constraints>
@@ -231,7 +231,7 @@
       <grid id="f9c12" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="10" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="11" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -259,7 +259,7 @@
       </grid>
       <component id="af108" class="javax.swing.JCheckBox" binding="myExcludeTargetFolderCheckBox">
         <constraints>
-          <grid row="8" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="9" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Exclude build directory (%PROJECT_ROOT%/target)"/>
@@ -268,7 +268,7 @@
       </component>
       <component id="2e377" class="javax.swing.JLabel">
         <constraints>
-          <grid row="15" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="16" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <labelFor value="83bca"/>
@@ -278,7 +278,7 @@
       </component>
       <component id="83bca" class="javax.swing.JTextField" binding="myDependencyTypes">
         <constraints>
-          <grid row="15" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="16" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="60" height="-1"/>
           </grid>
         </constraints>
@@ -289,13 +289,21 @@
       </component>
       <component id="d634c" class="com.intellij.ui.components.JBLabel">
         <constraints>
-          <grid row="16" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="9" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="17" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="9" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <componentStyle value="SMALL"/>
           <fontColor value="BRIGHTER"/>
           <labelFor value="83bca"/>
           <text resource-bundle="ProjectBundle" key="maven.import.dependency.type.description"/>
+        </properties>
+      </component>
+      <component id="d84a4" class="javax.swing.JCheckBox" binding="myPreferArtifactNameCheckBox">
+        <constraints>
+          <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Prefer artifact name over artifactId when naming modules"/>
         </properties>
       </component>
     </children>

--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/project/MavenImportingSettingsForm.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/project/MavenImportingSettingsForm.java
@@ -43,6 +43,7 @@ public class MavenImportingSettingsForm {
   private JCheckBox myImportAutomaticallyBox;
   private JCheckBox myCreateModulesForAggregators;
   private JCheckBox myCreateGroupsCheckBox;
+  private JCheckBox myPreferArtifactNameCheckBox;
   private JComboBox myUpdateFoldersOnImportPhaseComboBox;
   private JCheckBox myKeepSourceFoldersCheckBox;
   private JCheckBox myUseMavenOutputCheckBox;
@@ -112,6 +113,7 @@ public class MavenImportingSettingsForm {
     data.setImportAutomatically(myImportAutomaticallyBox.isSelected());
     data.setCreateModulesForAggregators(myCreateModulesForAggregators.isSelected());
     data.setCreateModuleGroups(myCreateGroupsCheckBox.isSelected());
+    data.setPreferArtifactName(myPreferArtifactNameCheckBox.isSelected());
 
     data.setKeepSourceFolders(myKeepSourceFoldersCheckBox.isSelected());
     data.setExcludeTargetFolder(myExcludeTargetFolderCheckBox.isSelected());
@@ -135,6 +137,7 @@ public class MavenImportingSettingsForm {
     myImportAutomaticallyBox.setSelected(data.isImportAutomatically());
     myCreateModulesForAggregators.setSelected(data.isCreateModulesForAggregators());
     myCreateGroupsCheckBox.setSelected(data.isCreateModuleGroups());
+    myPreferArtifactNameCheckBox.setSelected(data.isPreferArtifactName());
 
     myKeepSourceFoldersCheckBox.setSelected(data.isKeepSourceFolders());
     myExcludeTargetFolderCheckBox.setSelected(data.isExcludeTargetFolder());


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/IDEA-146390

This change adds configuration to the Maven project importer so that IntelliJ Modules can be named as per the _name_ element in the corresponding pom, rather than the _artifactId_.

Existing behaviour is preserved.

Main functional change starts on line 134 in MavenModuleNameMapper. The rest is plumbing to pass configuration in.

 See PR 448 in origin repo