### PR TITLE
[Fernflower] New Testing Type: stdout comparison tests (including new test cases)

### DIFF
--- a/plugins/java-decompiler/engine/build.xml
+++ b/plugins/java-decompiler/engine/build.xml
@@ -58,10 +58,11 @@
       </batchtest>
     </junit>
     <fail if="tests.failed" message="Tests failed."/>
+    <fail if="tests.stdout.failed" message="Stdout Tests failed."/>
   </target>
 
   <target name="test-stdout" depends="init,test-compile,test-stdout-prepare">
-    <junit printsummary="true" failureproperty="tests.failed" fork="true" >
+    <junit printsummary="true" failureproperty="tests.stdout.failed" fork="true" >
       <classpath path="${test-out}:${out}"/>
       <classpath refid="junit"/>
       <sysproperty key="stdout-tests.expected.dir" value="${stdout-tests.expected.dir}"/>
@@ -79,8 +80,6 @@
     <delete includeemptydirs="true" failonerror="false">
       <fileset dir="${stdout-tests.temp.dir}"/>
     </delete>
-    
-    <fail if="tests.failed" message="Tests failed."/>
   </target>
 
 

--- a/plugins/java-decompiler/engine/build.xml
+++ b/plugins/java-decompiler/engine/build.xml
@@ -84,7 +84,7 @@
   </target>
 
 
-  <target name="test-stdout-prepare" depends="init">
+  <target name="test-stdout-prepare" depends="init,test-compile">
     
     <!-- here you can skip tests -->
     <patternset id="stdout-tests.exclude.pattern">

--- a/plugins/java-decompiler/engine/build.xml
+++ b/plugins/java-decompiler/engine/build.xml
@@ -7,6 +7,7 @@
     <property name="dist" value="${basedir}/fernflower.jar"/>
     <property name="test-src" value="${basedir}/test"/>
     <property name="test-out" value="${basedir}/out/test"/>
+    <property name="test-data" value="${basedir}/testData"/>
   </target>
 
   <!-- external dependencies, adjust to your own -->
@@ -45,7 +46,10 @@
     </javac>
   </target>
 
-  <target name="test" depends="init,test-compile">
+
+  <target name="test" depends="test-stdout,test-normal"/>
+
+  <target name="test-normal" depends="init,test-compile">
     <junit printsummary="true" failureproperty="tests.failed" fork="true">
       <classpath path="${test-out}:${out}"/>
       <classpath refid="junit"/>
@@ -54,6 +58,139 @@
       </batchtest>
     </junit>
     <fail if="tests.failed" message="Tests failed."/>
+  </target>
+
+  <target name="test-stdout" depends="init,test-compile,test-stdout-prepare">
+    <junit printsummary="true" failureproperty="tests.failed" fork="true" >
+      <classpath path="${test-out}:${out}"/>
+      <classpath refid="junit"/>
+      <sysproperty key="stdout-tests.expected.dir" value="${stdout-tests.expected.dir}"/>
+      <sysproperty key="stdout-tests.decompile.dir"   value="${stdout-tests.decompile.dir}"/>
+      <batchtest >
+        <fileset dir="${test-src}" includes="**/StdoutCompareTestRunner.java"/>
+      </batchtest>
+      
+      <!-- look at output
+      <formatter type="plain" usefile="false" />
+      <formatter type="plain" />
+      -->
+    </junit>
+    <!-- clean up (delete tmp dir with all the output) -->
+    <delete includeemptydirs="true" failonerror="false">
+      <fileset dir="${stdout-tests.temp.dir}"/>
+    </delete>
+    
+    <fail if="tests.failed" message="Tests failed."/>
+  </target>
+
+
+  <target name="test-stdout-prepare" depends="init">
+    
+    <!-- here you can skip tests -->
+    <patternset id="stdout-tests.exclude.pattern">
+      <include name="**/*.java"/>
+      
+      <!-- general problems -->
+      <!-- non-compilable: causes private field/method access -->
+      <exclude name="**/PrivateAccess.java"/>
+      <!-- non-compilable: assertion code atm can only handle the throw in the if clause, not in the else clause -->
+      <exclude name="**/assertions/**/*"/>
+      <!-- overloading causes many troubles... -->
+      <exclude name="**/overloading/**/*"/>
+      <!-- non-compilable: renaming fails -->
+      <exclude name="**/renaming/**/*"/>
+      
+      <!-- old java versions -->
+      <!-- non-compilable: (.class field trouble with assert) (remove filter on assertions above too) -->
+      <exclude name="**/java14/assertions/**/*"/>
+      
+    </patternset>
+
+    <tempfile property="stdout-tests.temp.dir" destDir="${java.io.tmpdir}" prefix="decompiler_test_" suffix="_stdout-tests_dir"/>
+    <!--property name="stdout-tests.temp.dir" value="tmp_decompiler_test_stdout-tests_dir"/-->
+    <property name="stdout-tests.expected.dir" value="${stdout-tests.temp.dir}/expected"/>
+    <property name="stdout-tests.decompile.dir" value="${stdout-tests.temp.dir}/decompile"/>
+    
+    <property name="defaultJavaVersion" value="1.8"/>
+    
+    <!-- delete previous outputs if they exist -->
+    <delete includeemptydirs="true" failonerror="false">
+      <fileset dir="${stdout-tests.expected.dir}"/>
+      <fileset dir="${stdout-tests.decompile.dir}"/>
+    </delete>
+    
+    <mkdir dir="${stdout-tests.expected.dir}/classes"/>
+    <mkdir dir="${stdout-tests.expected.dir}/results"/>
+    <mkdir dir="${stdout-tests.decompile.dir}/classes"/>
+    <mkdir dir="${stdout-tests.decompile.dir}/results"/>
+    
+    <!-- compile (default java) the test cases from testData (packages in javadefault) -->
+    <javac srcdir="${test-data}/src-stdout" destdir="${stdout-tests.expected.dir}/classes"
+      source="${defaultJavaVersion}" target="${defaultJavaVersion}"
+      encoding="UTF-8" includeantruntime="false" failonerror="false">
+      <patternset>
+        <patternset includes="javadefault/**/*" />
+        <patternset refid="stdout-tests.exclude.pattern" />
+      </patternset>
+    </javac>
+    <!-- compile (java 1.4) the test cases from testData (packages in java14) -->
+    <javac srcdir="${test-data}/src-stdout" destdir="${stdout-tests.expected.dir}/classes"
+      source="1.4" target="1.4"
+      encoding="UTF-8" includeantruntime="false" failonerror="false">
+      <patternset>
+        <patternset includes="java14/**/*" />
+        <patternset refid="stdout-tests.exclude.pattern" />
+      </patternset>
+    </javac>
+    <!-- compile (java 1.5) the test cases from testData (packages in java15) -->
+    <javac srcdir="${test-data}/src-stdout" destdir="${stdout-tests.expected.dir}/classes"
+      source="1.5" target="1.5"
+      encoding="UTF-8" includeantruntime="false" failonerror="false">
+      <patternset>
+        <patternset includes="java15/**/*" />
+        <patternset refid="stdout-tests.exclude.pattern" />
+      </patternset>
+    </javac>
+    
+    <!-- run test cases from testData, stdout stored to compare later -->
+    <java classname="org.jetbrains.java.decompiler.StdoutCompareTestHelper" fork="true" failonerror="false">
+      <arg value="run"/>
+      <arg value="${stdout-tests.expected.dir}/results"/>
+      <!-- activate assertions to be able to test them -->
+      <jvmarg value="-ea"/>
+        
+      <classpath path="${test-out}"/>
+      <classpath path="${out}"/>
+      <classpath refid="junit"/>
+      <classpath path="${stdout-tests.expected.dir}/classes"/>
+    </java>
+    
+    <!-- decompile the classes -->
+    <java classname="org.jetbrains.java.decompiler.StdoutCompareTestHelper" fork="true" failonerror="false">
+      <arg value="decompile"/>
+      <arg value="${stdout-tests.expected.dir}/classes"/>
+      <arg value="${stdout-tests.decompile.dir}"/>
+        
+      <classpath path="${test-out}"/>
+      <classpath path="${out}"/>
+      <classpath refid="junit"/>
+    </java>
+    <!-- compile the decompiled classes -->
+    <javac srcdir="${stdout-tests.decompile.dir}/decompiled" destdir="${stdout-tests.decompile.dir}/classes"
+      source="${defaultJavaVersion}" target="${defaultJavaVersion}" encoding="UTF-8" includeantruntime="false" failonerror="false">
+    </javac>    
+    <!-- now run the decompiled classes -->
+    <java classname="org.jetbrains.java.decompiler.StdoutCompareTestHelper" fork="true" failonerror="false">
+      <arg value="run"/>
+      <arg value="${stdout-tests.decompile.dir}/results"/>
+      <!-- activate assertions to be able to test them -->
+      <jvmarg value="-ea"/>
+        
+      <classpath path="${test-out}"/>
+      <classpath path="${out}"/>
+      <classpath refid="junit"/>
+      <classpath path="${stdout-tests.decompile.dir}/classes"/>
+    </java>
   </target>
 
 </project>

--- a/plugins/java-decompiler/engine/test/org/jetbrains/java/decompiler/BulkDecompilationTest.java
+++ b/plugins/java-decompiler/engine/test/org/jetbrains/java/decompiler/BulkDecompilationTest.java
@@ -35,7 +35,7 @@ public class BulkDecompilationTest {
   @Before
   public void setUp() throws IOException {
     fixture = new DecompilerTestFixture();
-    fixture.setUp();
+    fixture.setUp(null);
   }
 
   @After

--- a/plugins/java-decompiler/engine/test/org/jetbrains/java/decompiler/DecompilerTestFixture.java
+++ b/plugins/java-decompiler/engine/test/org/jetbrains/java/decompiler/DecompilerTestFixture.java
@@ -35,10 +35,10 @@ public class DecompilerTestFixture {
   private File tempDir;
   private File targetDir;
   private ConsoleDecompiler decompiler;
+  private boolean deleteTempDirInCleanup;
 
-  public void setUp(String... optionPairs) throws IOException {
-    assertEquals(0, optionPairs.length % 2);
-
+  public static File findTestDataDir() throws IOException {
+    File testDataDir = new File("testData");
     testDataDir = new File("testData");
     if (!isTestDataDir(testDataDir)) testDataDir = new File("community/plugins/java-decompiler/engine/testData");
     if (!isTestDataDir(testDataDir)) testDataDir = new File("plugins/java-decompiler/engine/testData");
@@ -46,10 +46,24 @@ public class DecompilerTestFixture {
     if (!isTestDataDir(testDataDir)) testDataDir = new File("../plugins/java-decompiler/engine/testData");
     assertTrue("current dir: " + new File("").getAbsolutePath(), isTestDataDir(testDataDir));
     testDataDir = testDataDir.getAbsoluteFile();
+    return testDataDir;
+  }
+  
+  public void setUp(String externalTempDir, String... optionPairs) throws IOException {
+    assertEquals(0, optionPairs.length % 2);
 
-    //noinspection SSBasedInspection
-    tempDir = File.createTempFile("decompiler_test_", "_dir");
-    assertTrue(tempDir.delete());
+    testDataDir = findTestDataDir();
+
+    if (externalTempDir == null) {
+      deleteTempDirInCleanup = true;
+      //noinspection SSBasedInspection
+      tempDir = File.createTempFile("decompiler_test_", "_dir");
+      assertTrue(tempDir.delete());
+    }
+    else {
+      deleteTempDirInCleanup = false;
+      tempDir = new File(externalTempDir);
+    }
 
     targetDir = new File(tempDir, "decompiled");
     assertTrue(targetDir.mkdirs());
@@ -68,7 +82,7 @@ public class DecompilerTestFixture {
   }
 
   public void tearDown() {
-    if (tempDir != null) {
+    if (tempDir != null && deleteTempDirInCleanup) {
       delete(tempDir);
     }
   }

--- a/plugins/java-decompiler/engine/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+++ b/plugins/java-decompiler/engine/test/org/jetbrains/java/decompiler/SingleClassesTest.java
@@ -35,7 +35,7 @@ public class SingleClassesTest {
   @Before
   public void setUp() throws IOException {
     fixture = new DecompilerTestFixture();
-    fixture.setUp(IFernflowerPreferences.BYTECODE_SOURCE_MAPPING, "1",
+    fixture.setUp(null, IFernflowerPreferences.BYTECODE_SOURCE_MAPPING, "1",
                   IFernflowerPreferences.DUMP_ORIGINAL_LINES, "1");
   }
 
@@ -83,12 +83,9 @@ public class SingleClassesTest {
   @Test public void testMethodReferenceSameName() { doTest("pkg/TestMethodReferenceSameName"); }
   @Test public void testMethodReferenceLetterClass() { doTest("pkg/TestMethodReferenceLetterClass"); }
   @Test public void testMemberAnnotations() { doTest("pkg/TestMemberAnnotations"); }
-  @Test public void testMoreAnnotations() { doTest("pkg/MoreAnnotations"); }
-  @Test public void testTypeAnnotations() { doTest("pkg/TypeAnnotations"); }
   @Test public void testStaticNameClash() { doTest("pkg/TestStaticNameClash"); }
   @Test public void testExtendingSubclass() { doTest("pkg/TestExtendingSubclass"); }
   @Test public void testSyntheticAccess() { doTest("pkg/TestSyntheticAccess"); }
-  @Test public void testIllegalVarName() { doTest("pkg/TestIllegalVarName"); }
 
   private void doTest(String testFile, String... companionFiles) {
     ConsoleDecompiler decompiler = fixture.getDecompiler();

--- a/plugins/java-decompiler/engine/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+++ b/plugins/java-decompiler/engine/test/org/jetbrains/java/decompiler/SingleClassesTest.java
@@ -83,9 +83,12 @@ public class SingleClassesTest {
   @Test public void testMethodReferenceSameName() { doTest("pkg/TestMethodReferenceSameName"); }
   @Test public void testMethodReferenceLetterClass() { doTest("pkg/TestMethodReferenceLetterClass"); }
   @Test public void testMemberAnnotations() { doTest("pkg/TestMemberAnnotations"); }
+  @Test public void testMoreAnnotations() { doTest("pkg/MoreAnnotations"); }
+  @Test public void testTypeAnnotations() { doTest("pkg/TypeAnnotations"); }
   @Test public void testStaticNameClash() { doTest("pkg/TestStaticNameClash"); }
   @Test public void testExtendingSubclass() { doTest("pkg/TestExtendingSubclass"); }
   @Test public void testSyntheticAccess() { doTest("pkg/TestSyntheticAccess"); }
+  @Test public void testIllegalVarName() { doTest("pkg/TestIllegalVarName"); }
 
   private void doTest(String testFile, String... companionFiles) {
     ConsoleDecompiler decompiler = fixture.getDecompiler();

--- a/plugins/java-decompiler/engine/test/org/jetbrains/java/decompiler/StdoutCompareTestHelper.java
+++ b/plugins/java-decompiler/engine/test/org/jetbrains/java/decompiler/StdoutCompareTestHelper.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2000-2016 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetbrains.java.decompiler;
+
+import org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler;
+import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.lang.reflect.Method;
+import java.util.*;
+
+import static org.jetbrains.java.decompiler.DecompilerTestFixture.assertFilesEqual;
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * Runs all main() methods in, puts stdout output into file.
+ *
+ */
+
+public class StdoutCompareTestHelper {
+
+  private static DecompilerTestFixture createDecompiler(String externalTempDir) throws IOException {
+    List<String> params = new ArrayList<String>();
+
+    params.add(IFernflowerPreferences.RENAME_ENTITIES);
+    params.add("1");
+
+    //params.add(IFernflowerPreferences.DECOMPILE_ASSERTIONS);
+    //params.add("0");
+    
+    DecompilerTestFixture fixture;
+    fixture = new DecompilerTestFixture();
+    fixture.setUp(externalTempDir, params.toArray(new String[0]));
+    return fixture;
+  }
+
+
+  private static void runAllMain(List<String> classNames, String outputDir) throws Exception {
+    for (String className: classNames) {
+      //it could be that we don't find a class because it was renamed on decompile
+      //we care about that during output comparison of test (class containing main must not be renamed)
+      Method meth = null;
+      try {
+        Class<?> cl = Class.forName(className);
+        meth = cl.getMethod("main", String[].class);
+      }
+      catch (Exception e) {
+        //write a skip file so we know we are skipping tests...
+        String outFileName = outputDir + "/" + className + ".skip.txt";
+        PrintStream out = new PrintStream(outFileName);
+        out.println(e);
+        out.close();
+      }
+      if (meth != null) {
+        PrintStream origOut = System.out;
+        PrintStream newOut = null;
+        PrintStream exceptionOut = null;
+        try {
+          String outFileName = outputDir + "/" + className + ".output.txt";
+          newOut = new PrintStream(outFileName);
+          System.setOut(newOut);
+          meth.invoke(null, new Object[] {new String[] {}});
+        }
+        catch (Exception e) {
+          //we don't throw here: if no output file exists we know it failed later during test run
+          //throw new RuntimeException("Running " + className + " failed: " + e);
+          //File exceptionFile = new File(outputDir + "/" + className + ".exception.txt");
+          String exceptionFile = outputDir + "/" + className + ".exception.txt";
+          exceptionOut = new PrintStream(exceptionFile);
+          exceptionOut.append(e.toString() + "\n");
+          e.printStackTrace(exceptionOut);
+        }
+        finally {
+          System.setOut(origOut);
+          if (newOut != null) {
+            newOut.close();
+          }
+          if (exceptionOut != null) {
+            exceptionOut.close();
+          }
+        }
+      }
+    }
+  }
+
+
+  public static List<String> getAllClassNames() throws IOException {
+    File testDataDir = DecompilerTestFixture.findTestDataDir();
+    File stdoutTestsJavaRoot = new File(testDataDir.getPath() + "/src-stdout/");
+
+    List<File> javaFiles = collectFiles(stdoutTestsJavaRoot, ".java");
+
+    //System.out.println("DEBUG: found this java files: " + javaFiles);
+
+    List<String> classNames = new ArrayList<String>();
+    for(File f: javaFiles) {
+      String n = f.getPath().replace(stdoutTestsJavaRoot.getPath(), "");
+      n = n.substring(1);
+      n = n.replace(".java", "").replace('/', '.');
+
+      classNames.add(n);
+    }
+    //System.out.println("DEBUG: found this java names: " + classNames);
+    return classNames;
+  }
+
+
+  private static void run(String outputDir) throws Exception {
+    List<String> classNames = getAllClassNames();
+    runAllMain(classNames, outputDir);
+  }
+
+
+  public static List<File> collectFiles(File dir, String endsWith) {
+    //System.out.println("DEBUG: looking for " + endsWith + " files in: " + dir.getPath());
+    if (dir == null || !dir.isDirectory()) {
+      throw new RuntimeException("ERROR: expecting directory");
+    }
+    List<File> files = new ArrayList<File>();
+
+    for (File f: dir.listFiles()) {
+      if (f.isFile() && f.getName().endsWith(endsWith)) {
+        files.add(f);
+      }
+      else if (f.isDirectory()) {
+        files.addAll(collectFiles(f, endsWith));
+      }
+    }
+    return files;
+  }
+
+  /**
+   * creates the expected output, which is used by the tests to compare to
+   * @param args
+   */
+  public static void main(String[] args) {
+    String me = StdoutCompareTestHelper.class.getName();
+    try {
+      if (args.length < 1) {
+        System.err.println("'" + me + "' expects parameters");
+        return;
+      }
+      if (args[0].equals("run")) {
+        if (args.length != 2) {
+          System.err.println("Correct usage would be '" + me + " run <outputDir>'");
+          return;
+        }
+        else {
+          String outputDir = args[1];
+          run(outputDir);
+        }
+      }
+      else if (args[0].equals("decompile")) {
+        if (args.length != 3) {
+          System.err.println("Expecing <decompile-command> <classes_dir> <output_dir>'");
+          return;
+        }
+        DecompilerTestFixture fixture = createDecompiler(args[2]);
+        ConsoleDecompiler decompiler = fixture.getDecompiler();
+        decompiler.addSpace(new File(args[1]), true);
+        decompiler.decompileContext();
+      }
+      else {
+        System.err.println(me + " got unexpected command.");
+        return;
+      }
+    }
+    catch (Throwable t) {
+      System.err.println(me + " failed: " + t);
+    }
+  }
+}

--- a/plugins/java-decompiler/engine/test/org/jetbrains/java/decompiler/StdoutCompareTestHelper.java
+++ b/plugins/java-decompiler/engine/test/org/jetbrains/java/decompiler/StdoutCompareTestHelper.java
@@ -15,21 +15,15 @@
  */
 package org.jetbrains.java.decompiler;
 
-import org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler;
-import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.io.File;
-import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.lang.reflect.Method;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
-import static org.jetbrains.java.decompiler.DecompilerTestFixture.assertFilesEqual;
-import static org.junit.Assert.assertTrue;
+import org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler;
+import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
 
 
 /**
@@ -59,17 +53,25 @@ public class StdoutCompareTestHelper {
     for (String className: classNames) {
       //it could be that we don't find a class because it was renamed on decompile
       //we care about that during output comparison of test (class containing main must not be renamed)
+      Class<?> cl = null;
       Method meth = null;
       try {
-        Class<?> cl = Class.forName(className);
-        meth = cl.getMethod("main", String[].class);
+        cl = Class.forName(className);
       }
-      catch (Exception e) {
-        //write a skip file so we know we are skipping tests...
+      catch (ClassNotFoundException e) {
+        //write a skip file so we know we are skipping tests... (it normally means test case is disabled in build.xml)
         String outFileName = outputDir + "/" + className + ".skip.txt";
         PrintStream out = new PrintStream(outFileName);
         out.println(e);
         out.close();
+      }
+      if (cl != null) {
+        try {
+          meth = cl.getMethod("main", String[].class);
+        }
+        catch (NoSuchMethodException e) {
+          // no problem, this class has no main method
+        }
       }
       if (meth != null) {
         PrintStream origOut = System.out;

--- a/plugins/java-decompiler/engine/test/org/jetbrains/java/decompiler/StdoutCompareTestRunner.java
+++ b/plugins/java-decompiler/engine/test/org/jetbrains/java/decompiler/StdoutCompareTestRunner.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2000-2016 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetbrains.java.decompiler;
+
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.regex.Pattern;
+
+import static org.jetbrains.java.decompiler.DecompilerTestFixture.assertFilesEqual;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+public class StdoutCompareTestRunner {
+  private String stdoutExpectedPath;
+  private String stdoutPath;
+  private boolean skip;
+
+  private static String expectedBaseDir = System.getProperty("stdout-tests.expected.dir");
+  private static String decompileBaseDir = System.getProperty("stdout-tests.decompile.dir");
+
+  public StdoutCompareTestRunner(String testName, String stdoutExpectedPath, String stdoutPath, boolean skip) {
+    this.stdoutExpectedPath = stdoutExpectedPath;
+    this.stdoutPath = stdoutPath;
+    this.skip = skip;
+  }
+
+  /**
+   * @return list with constructor arguments, first one is used in test name
+   */
+  @Parameters(name = "{0}")
+  public static Collection<Object[]> data() {
+    Collection<Object[]> ctorParams = new ArrayList<Object[]>();
+
+    File expectedDir = new File(expectedBaseDir + "/results");
+    FilenameFilter filter = new FilenameFilter() {
+      @Override
+      public boolean accept(File dir, String name) {
+        return name.endsWith(".output.txt") || name.endsWith(".skip.txt");
+      }
+    };
+    File[] files = expectedDir.listFiles(filter);
+    if (files != null) {
+      for(File f: files) {
+        String normalName = decompileBaseDir + "/results/" + f.getName();
+        String caseName;
+        boolean skip = false;
+        if (f.getName().endsWith(".output.txt")) {
+          caseName = f.getName().replace(".output.txt", "");
+        }
+        else {
+          caseName = f.getName().replace(".skip.txt", "");
+          skip = true;
+        }
+        ctorParams.add(new Object[] { caseName, f.getPath(), normalName, skip});
+      }
+    }
+    return ctorParams;
+  }
+
+
+
+  @Before
+  public void setUp() throws IOException {
+  }
+
+  @After
+  public void tearDown() {
+  }
+
+
+  @Test
+  public void compareStdoutTest() throws Exception{
+    //skip test if the expected output was 'skip'
+    Assume.assumeFalse("Skipped because no expected output. That normally means test is disabled per stdout-tests.exclude.pattern from build.xml.", skip);
+    
+    File stdoutExpected = new File(stdoutExpectedPath);
+    File stdout = new File(stdoutPath);
+
+    assertTrue("Error in test, this should not happen (expected output not found)", stdoutExpected.isFile());
+    assertTrue("Did not find output (was compilation of case disabled (see build.xml) because it would fail?), at: " + stdoutExpected.getPath(), stdout.isFile());
+
+    assertFilesEqual(stdoutExpected, stdout);
+
+    File exceptionFile = new File(stdout.getPath().replace(".output.txt", ".exception.txt"));
+    File exceptionExpectedFile = new File(stdoutExpected.getPath().replace(".output.txt", ".exception.txt"));
+
+    //main of tests should not throw!!! but we check if it did in run of original classes too
+    assertTrue("Original classes did throw from main on running, fix the test.", !exceptionExpectedFile.isFile());
+    assertTrue("The decompiled code threw an unexpected exception: " + exceptionFile.getPath(), !exceptionFile.isFile());
+
+    validatePatterns(stdoutExpected, stdout);
+  }
+
+  private void validatePatterns(File stdoutExpected, File stdout) throws Exception {
+
+    //check stdout if there are patterns for it provided
+    //construct path of pattern file:
+    String baseFileName = stdoutExpected.getAbsolutePath().replace(new File(expectedBaseDir).getAbsolutePath() + "/results/", "");
+    baseFileName = baseFileName.replace(".output.txt", "").replace(".", "/");
+
+    File testData = DecompilerTestFixture.findTestDataDir();
+    File patternFile = new File(testData.getPath() + "/src-stdout/" + baseFileName  + ".pattern.txt");
+    //System.out.println("DEBUG: looking for pattern file: " + patternFile.getPath());
+    if (patternFile.isFile()) {
+      //System.out.println("DEBUG: pattern file found: " + patternFile.getPath());
+
+      //get decompiled java file:
+      String javaBaseDir = decompileBaseDir + "/decompiled/";
+
+      String javaFilePath = javaBaseDir + baseFileName.replace(".", "/") + ".java";
+      String javaContent = new String(Files.readAllBytes(Paths.get(javaFilePath)));
+
+      List<String[]> patterns = parsePatternFile(patternFile);
+      for (String[] p: patterns) {
+        //System.out.println("DEBUG: using pattern (" + p[0] + "): " + p[1]);
+
+
+        Pattern pat = Pattern.compile(".*?" + p[1] + ".*?", Pattern.DOTALL | Pattern.MULTILINE);
+        if (p[0].equals("matches")) {
+          assertTrue("Matches regex (" + p[1] + ") failed on: " + javaFilePath, pat.matcher(javaContent).matches());
+        }
+        else {
+          assertTrue("Not matches regex (" + p[1] + ") failed on " + javaFilePath, !pat.matcher(javaContent).matches());
+        }
+      }
+    }
+  }
+
+  /**
+   * @return entrys: match_type {'matches', '!matches'}, regex
+   */
+  private List<String[]> parsePatternFile(File f) throws Exception {
+    // 
+    List<String[]> res = new ArrayList<String[]>();
+    BufferedReader br = new BufferedReader(new FileReader(f));
+    String cur = null;
+    while ((cur = br.readLine()) != null) {
+      String errMsg = "Pattern file (" + f.getPath() + ") syntax error in line: " + cur;
+      cur = cur.trim();
+      if (cur.length() == 0 || cur.charAt(0) == '#') {
+        continue;
+      }
+      assertTrue(errMsg, cur.indexOf(':') > 0);
+      String t = cur.substring(0, cur.indexOf(':'));
+      String v = cur.substring(cur.indexOf(':') + 1, cur.length()).trim();
+
+      assertTrue(errMsg, t.equals("matches") || t.equals("!matches"));
+      res.add(new String[] { t, v});
+    }
+    br.close();
+    return res;
+  }
+}
+
+

--- a/plugins/java-decompiler/engine/testData/src-stdout/java14/assertions/Assert1.java
+++ b/plugins/java-decompiler/engine/testData/src-stdout/java14/assertions/Assert1.java
@@ -1,0 +1,110 @@
+package java14.assertions;
+
+/**
+ * Fails because java14 .class access:
+ * $assertionsDisabled is not found as statically initialized field.
+ * It looks like this:
+ * $assertionsDisabled = !(class$java14$assertions$Assert1 == null?(class$java14$assertions$Assert1 = class$("java14.assertions.Assert1")):class$java14$assertions$Assert1).desiredAssertionStatus()
+ * 
+ * isExprentIndependent() returns false because there is a EXPRENT_FIELD in this.
+ */
+
+public class Assert1 {
+  public static int i = 1;
+  public static int j = 2;
+  public static int x = 3;
+  public static int y = 4;
+  public static int z = 5;
+  
+  
+  public static void testWithNumbers(int i, int j, int k) {
+    try {
+      assert i > 0 || j > 0 || k > 0: "Msg 0";
+      if (i < j) {
+        assert i != 0 && j != 1 || k != 0: "Msg 1";
+        if (i == k) {
+          assert k == 2: "Msg 1.1";
+        }
+      }
+      else if (i > j && i == 2) {
+        assert i != 1 && k != 0: "Msg 2";
+        if (j == 0) {
+          assert j > k: "Msg 2.1";
+        }
+        else {
+          assert i < 2: "Msg 2.2";
+        }
+      }
+      else if (k != 1 || i == j) {
+        System.out.println("elif2: " + i + " " + j + " " + k);
+        assert k != 0: "Msg 3";
+        System.out.println(".");
+        if (k == 2 && i == 1) {
+          System.out.println("..");
+          assert j < 0: "Msg 3.1";
+          System.out.println("...");
+        }
+        else {
+          System.out.println("....");
+          assert k < 0: "Msg 3.2";
+          System.out.println(".....");
+        }
+      }
+      else {
+        assert !(i > j && i == 1) && k < 0: "Msg 4";
+      }
+      
+      assert false: "Msg final";
+    }
+    catch (AssertionError e) {
+      System.out.println(i + " " + j + " " + k + " got AssertionError: " + e);
+    }
+  }
+  
+  //try to force the "or case": if($assertionsDisabled || ...
+  public static int foo(Object x) {
+    assert (x.toString().equals("x") && i < j) || (i > j && y == i);
+    return 1;
+  }
+  
+  public static void main(String[] args) {
+    try {
+      assert i + y > z -2;
+      if (i < 3) {
+        System.out.println("1");
+        assert i < 2;
+        System.out.println("2");
+        if (j > -3) {
+          System.out.println("3");
+          assert z > y;
+          System.out.println("4");
+        }
+        else if (z > j) {
+          System.out.println("5");
+          assert z > i;
+          System.out.println("6");
+        }
+        else {
+          System.out.println("7");
+          assert z > i;
+          System.out.println("8");
+        }
+      }
+      assert z > i + 2;
+      
+      for (int i = 0; i < 3; i++) {
+        for (int j = 0; j < 3; j++) {
+          for (int k = 0; k < 3; k++) {
+            System.out.println("testWithNumbers: " + i + " " + j + " " + k);
+            testWithNumbers(i,j,k);
+          }
+        }
+      }
+      
+      foo(new Assert1());
+    }
+    catch (AssertionError e) {
+      System.out.println("Got AssertionError: " + e);
+    }
+  }
+}

--- a/plugins/java-decompiler/engine/testData/src-stdout/java14/assertions/Assert1.pattern.txt
+++ b/plugins/java-decompiler/engine/testData/src-stdout/java14/assertions/Assert1.pattern.txt
@@ -1,0 +1,5 @@
+# this problem does only exist with old java versions, e.g. compile for 1.4 to see it
+
+!matches:[$]assertionsDisabled
+!matches:throw new AssertionError
+

--- a/plugins/java-decompiler/engine/testData/src-stdout/java14/assertions/Assert2.java
+++ b/plugins/java-decompiler/engine/testData/src-stdout/java14/assertions/Assert2.java
@@ -1,0 +1,69 @@
+package java14.assertions;
+
+/**
+ * same problem as Assert1 for java14
+ */
+
+public class Assert2 {
+  public static int i = 1;
+  public static int j = 2;
+  public static int x = 3;
+  public static int y = 4;
+  public static int z = 5;
+  
+  public void testWithNumbers(int i, int j, int k) {
+    try {
+      assert i > 0 || j > 0 || k > 0: "Msg 0";
+      if (i < j) {
+        assert i != 0 && j != 1 || k != 0: "Msg 1";
+        if (i == k) {
+          assert k == 2: "Msg 1.1";
+        }
+      }
+      else if (i > j && i == 2) {
+        assert i != 1 && k != 0: "Msg 2";
+        if (j == 0) {
+          assert j > k: "Msg 2.1";
+        }
+        else {
+          assert i < 2: "Msg 2.2";
+        }
+      }
+      else if (k != 1 || i == j) {
+        System.out.println("elif2: " + i + " " + j + " " + k);
+        assert k != 0: "Msg 3";
+        System.out.println(".");
+        if (k == 2 && i == 1) {
+          System.out.println("..");
+          assert j < 0: "Msg 3.1";
+          System.out.println("...");
+        }
+        else {
+          System.out.println("....");
+          assert k < 0: "Msg 3.2";
+          System.out.println(".....");
+        }
+      }
+      else {
+        assert !(i > j && i == 1) && k < 0: "Msg 4";
+      }
+      
+      assert false: "Msg final";
+    }
+    catch (AssertionError e) {
+      System.out.println(i + " " + j + " " + k + " got AssertionError: " + e);
+    }
+  }
+  
+  public static void main(String[] args) {
+    Assert2 a = new Assert2();
+    for (int i = 0; i < 3; i++) {
+      for (int j = 0; j < 3; j++) {
+        for (int k = 0; k < 3; k++) {
+          System.out.println("testWithNumbers: " + i + " " + j + " " + k);
+          a.testWithNumbers(i,j,k);
+        }
+      }
+    }
+  }
+}

--- a/plugins/java-decompiler/engine/testData/src-stdout/java14/assertions/Assert2.pattern.txt
+++ b/plugins/java-decompiler/engine/testData/src-stdout/java14/assertions/Assert2.pattern.txt
@@ -1,0 +1,5 @@
+# this problem does only exist with old java versions, e.g. compile for 1.4 to see it
+
+!matches:[$]assertionsDisabled
+!matches:throw new AssertionError
+

--- a/plugins/java-decompiler/engine/testData/src-stdout/java15/assertions/Assert1.java
+++ b/plugins/java-decompiler/engine/testData/src-stdout/java15/assertions/Assert1.java
@@ -1,0 +1,103 @@
+package java15.assertions;
+
+/**
+ */
+
+public class Assert1 {
+  public static int i = 1;
+  public static int j = 2;
+  public static int x = 3;
+  public static int y = 4;
+  public static int z = 5;
+  
+  public static void testWithNumbers(int i, int j, int k) {
+    try {
+      assert i > 0 || j > 0 || k > 0: "Msg 0";
+      if (i < j) {
+        assert i != 0 && j != 1 || k != 0: "Msg 1";
+        if (i == k) {
+          assert k == 2: "Msg 1.1";
+        }
+      }
+      else if (i > j && i == 2) {
+        assert i != 1 && k != 0: "Msg 2";
+        if (j == 0) {
+          assert j > k: "Msg 2.1";
+        }
+        else {
+          assert i < 2: "Msg 2.2";
+        }
+      }
+      else if (k != 1 || i == j) {
+        System.out.println("elif2: " + i + " " + j + " " + k);
+        assert k != 0: "Msg 3";
+        System.out.println(".");
+        if (k == 2 && i == 1) {
+          System.out.println("..");
+          assert j < 0: "Msg 3.1";
+          System.out.println("...");
+        }
+        else {
+          System.out.println("....");
+          assert k < 0: "Msg 3.2";
+          System.out.println(".....");
+        }
+      }
+      else {
+        assert !(i > j && i == 1) && k < 0: "Msg 4";
+      }
+      
+      assert false: "Msg final";
+    }
+    catch (AssertionError e) {
+      System.out.println(i + " " + j + " " + k + " got AssertionError: " + e);
+    }
+  }
+  
+  //try to force the "or case": if($assertionsDisabled || ...
+  public static int foo(Object x) {
+    assert (x.toString().equals("x") && i < j) || (i > j && y == i);
+    return 1;
+  }
+  
+  public static void main(String[] args) {
+    try {
+      assert i + y > z -2;
+      if (i < 3) {
+        System.out.println("1");
+        assert i < 2;
+        System.out.println("2");
+        if (j > -3) {
+          System.out.println("3");
+          assert z > y;
+          System.out.println("4");
+        }
+        else if (z > j) {
+          System.out.println("5");
+          assert z > i;
+          System.out.println("6");
+        }
+        else {
+          System.out.println("7");
+          assert z > i;
+          System.out.println("8");
+        }
+      }
+      assert z > i + 2;
+      
+      for (int i = 0; i < 3; i++) {
+        for (int j = 0; j < 3; j++) {
+          for (int k = 0; k < 3; k++) {
+            System.out.println("testWithNumbers: " + i + " " + j + " " + k);
+            testWithNumbers(i,j,k);
+          }
+        }
+      }
+      
+      foo(new Assert1());
+    }
+    catch (AssertionError e) {
+      System.out.println("Got AssertionError: " + e);
+    }
+  }
+}

--- a/plugins/java-decompiler/engine/testData/src-stdout/java15/assertions/Assert1.pattern.txt
+++ b/plugins/java-decompiler/engine/testData/src-stdout/java15/assertions/Assert1.pattern.txt
@@ -1,0 +1,5 @@
+# this problem does only exist with old java versions, e.g. compile for 1.4 to see it
+
+!matches:[$]assertionsDisabled
+!matches:throw new AssertionError
+

--- a/plugins/java-decompiler/engine/testData/src-stdout/java15/assertions/Assert2.java
+++ b/plugins/java-decompiler/engine/testData/src-stdout/java15/assertions/Assert2.java
@@ -1,0 +1,69 @@
+package java15.assertions;
+
+/**
+ * similar to Assert1, but asserts used on instance and not in static methods
+ */
+
+public class Assert2 {
+  public static int i = 1;
+  public static int j = 2;
+  public static int x = 3;
+  public static int y = 4;
+  public static int z = 5;
+  
+  public void testWithNumbers(int i, int j, int k) {
+    try {
+      assert i > 0 || j > 0 || k > 0: "Msg 0";
+      if (i < j) {
+        assert i != 0 && j != 1 || k != 0: "Msg 1";
+        if (i == k) {
+          assert k == 2: "Msg 1.1";
+        }
+      }
+      else if (i > j && i == 2) {
+        assert i != 1 && k != 0: "Msg 2";
+        if (j == 0) {
+          assert j > k: "Msg 2.1";
+        }
+        else {
+          assert i < 2: "Msg 2.2";
+        }
+      }
+      else if (k != 1 || i == j) {
+        System.out.println("elif2: " + i + " " + j + " " + k);
+        assert k != 0: "Msg 3";
+        System.out.println(".");
+        if (k == 2 && i == 1) {
+          System.out.println("..");
+          assert j < 0: "Msg 3.1";
+          System.out.println("...");
+        }
+        else {
+          System.out.println("....");
+          assert k < 0: "Msg 3.2";
+          System.out.println(".....");
+        }
+      }
+      else {
+        assert !(i > j && i == 1) && k < 0: "Msg 4";
+      }
+      
+      assert false: "Msg final";
+    }
+    catch (AssertionError e) {
+      System.out.println(i + " " + j + " " + k + " got AssertionError: " + e);
+    }
+  }
+  
+  public static void main(String[] args) {
+    Assert2 a = new Assert2();
+    for (int i = 0; i < 3; i++) {
+      for (int j = 0; j < 3; j++) {
+        for (int k = 0; k < 3; k++) {
+          System.out.println("testWithNumbers: " + i + " " + j + " " + k);
+          a.testWithNumbers(i,j,k);
+        }
+      }
+    }
+  }
+}

--- a/plugins/java-decompiler/engine/testData/src-stdout/java15/assertions/Assert2.pattern.txt
+++ b/plugins/java-decompiler/engine/testData/src-stdout/java15/assertions/Assert2.pattern.txt
@@ -1,0 +1,5 @@
+# this problem does only exist with old java versions, e.g. compile for 1.4 to see it
+
+!matches:[$]assertionsDisabled
+!matches:throw new AssertionError
+

--- a/plugins/java-decompiler/engine/testData/src-stdout/javadefault/assertions/Assert1.java
+++ b/plugins/java-decompiler/engine/testData/src-stdout/javadefault/assertions/Assert1.java
@@ -1,0 +1,103 @@
+package javadefault.assertions;
+
+/**
+ */
+
+public class Assert1 {
+  public static int i = 1;
+  public static int j = 2;
+  public static int x = 3;
+  public static int y = 4;
+  public static int z = 5;
+  
+  public static void testWithNumbers(int i, int j, int k) {
+    try {
+      assert i > 0 || j > 0 || k > 0: "Msg 0";
+      if (i < j) {
+        assert i != 0 && j != 1 || k != 0: "Msg 1";
+        if (i == k) {
+          assert k == 2: "Msg 1.1";
+        }
+      }
+      else if (i > j && i == 2) {
+        assert i != 1 && k != 0: "Msg 2";
+        if (j == 0) {
+          assert j > k: "Msg 2.1";
+        }
+        else {
+          assert i < 2: "Msg 2.2";
+        }
+      }
+      else if (k != 1 || i == j) {
+        System.out.println("elif2: " + i + " " + j + " " + k);
+        assert k != 0: "Msg 3";
+        System.out.println(".");
+        if (k == 2 && i == 1) {
+          System.out.println("..");
+          assert j < 0: "Msg 3.1";
+          System.out.println("...");
+        }
+        else {
+          System.out.println("....");
+          assert k < 0: "Msg 3.2";
+          System.out.println(".....");
+        }
+      }
+      else {
+        assert !(i > j && i == 1) && k < 0: "Msg 4";
+      }
+      
+      assert false: "Msg final";
+    }
+    catch (AssertionError e) {
+      System.out.println(i + " " + j + " " + k + " got AssertionError: " + e);
+    }
+  }
+  
+  //try to force the "or case": if($assertionsDisabled || ...
+  public static int foo(Object x) {
+    assert (x.toString().equals("x") && i < j) || (i > j && y == i);
+    return 1;
+  }
+  
+  public static void main(String[] args) {
+    try {
+      assert i + y > z -2;
+      if (i < 3) {
+        System.out.println("1");
+        assert i < 2;
+        System.out.println("2");
+        if (j > -3) {
+          System.out.println("3");
+          assert z > y;
+          System.out.println("4");
+        }
+        else if (z > j) {
+          System.out.println("5");
+          assert z > i;
+          System.out.println("6");
+        }
+        else {
+          System.out.println("7");
+          assert z > i;
+          System.out.println("8");
+        }
+      }
+      assert z > i + 2;
+      
+      for (int i = 0; i < 3; i++) {
+        for (int j = 0; j < 3; j++) {
+          for (int k = 0; k < 3; k++) {
+            System.out.println("testWithNumbers: " + i + " " + j + " " + k);
+            testWithNumbers(i,j,k);
+          }
+        }
+      }
+      
+      foo(new Assert1());
+    }
+    catch (AssertionError e) {
+      System.out.println("Got AssertionError: " + e);
+    }
+  }
+}

--- a/plugins/java-decompiler/engine/testData/src-stdout/javadefault/assertions/Assert1.pattern.txt
+++ b/plugins/java-decompiler/engine/testData/src-stdout/javadefault/assertions/Assert1.pattern.txt
@@ -1,0 +1,5 @@
+# this problem does only exist with old java versions, e.g. compile for 1.4 to see it
+
+!matches:[$]assertionsDisabled
+!matches:throw new AssertionError
+

--- a/plugins/java-decompiler/engine/testData/src-stdout/javadefault/exampletest/Sample.java
+++ b/plugins/java-decompiler/engine/testData/src-stdout/javadefault/exampletest/Sample.java
@@ -1,0 +1,19 @@
+package javadefault.exampletest;
+
+public class Sample {
+  
+    //all main methods will be called automatically, stdout will be compared
+    public static void main(String[] args) {
+        System.out.println("Dummy Test output...");
+        X x = new X();
+        x.f();
+    }
+    
+    //this will be renamed by renamer, don't print stuff that depends on the names
+    //if the names are so that renamer kicks in...
+    public static class X {
+      public void f() {
+        System.out.println("called X.f(), but because of active renaming, it would be different name in decompiled case...");
+      }
+    }
+}

--- a/plugins/java-decompiler/engine/testData/src-stdout/javadefault/exampletest/Sample.pattern.txt
+++ b/plugins/java-decompiler/engine/testData/src-stdout/javadefault/exampletest/Sample.pattern.txt
@@ -1,0 +1,17 @@
+# A Pattern file (optional)
+
+# You can match patterns in the decompiled java files with it (e.g. make sure no synthetics)
+
+# You give pattern in java regex syntax, applied to the whole java file (multiline|dotall, '.*?' appended and prepended automatically)
+# NOTE: you can only define a pattern file for a class containing a main method
+# NOTE: each line is stripped of whitespace at begin and end, so use [ ] to match space at end
+
+
+# decompiled java file content must contain (java regex syntax):
+matches:System[.]out[.]println
+
+# decompiled java file must not contain:
+!matches:[$]assertionsDisabled
+
+
+

--- a/plugins/java-decompiler/engine/testData/src-stdout/javadefault/overloading/PrivateAccess.java
+++ b/plugins/java-decompiler/engine/testData/src-stdout/javadefault/overloading/PrivateAccess.java
@@ -1,0 +1,74 @@
+package javadefault.overloading;
+
+/**
+ * because of missing casts it created code that accessed private fields and methods...
+ */
+public class PrivateAccess {
+    private int i = 1;
+    private void bar(String x) {
+      System.out.println("PrivateAccess bar called (private)");
+    }
+    
+    public void foo(Inner inner) {
+        ((PrivateAccess) inner).i = 2;
+        //this decompiles to the following, which is illegal (private field access):
+        //inner.i = 2;
+        
+        ((PrivateAccess) inner).bar("");
+        //this decompiles to the following, which is illegal (private method access):
+        //inner.bar("");
+    }
+    
+    
+    public void foo2(Inner2 inner) {
+        ((PrivateAccess) inner).i = 2;
+        ((PrivateAccess) inner).bar("");
+        inner.i = 2;
+        inner.bar("");
+        PrivateAccess fb = new Inner2();
+        ((Inner2) fb).i=2;
+        ((Inner2) fb).bar("");
+        fb.i=3;
+        fb.bar("");
+    }
+
+    public void foo3(Inner3 inner) {
+        ((PrivateAccess) inner).i = 2;
+        ((PrivateAccess) inner).bar("");
+        inner.i = 2;
+        inner.bar("");
+        PrivateAccess fb = new Inner3();
+        ((Inner3) fb).i=2;
+        ((Inner3) fb).bar("");
+        fb.i=3;
+        fb.bar("");
+    }
+    
+    ///main
+    public static void main(String[] args) {
+        new PrivateAccess().foo(new Inner());
+        new PrivateAccess().foo2(new Inner2());
+        new PrivateAccess().foo3(new Inner3());
+    }
+    
+    
+    public static class Inner extends PrivateAccess {}
+ 
+    ///test other cases:
+    public static class Inner2 extends PrivateAccess {
+        private int i = 2;
+        private void bar(String x) {
+          System.out.println("Inner2 bar called");
+        }
+    }
+    
+    ///test other cases:
+    public static class Inner3 extends PrivateAccess {
+        public int i = 2;
+        public void bar(String x) {
+          System.out.println("Inner3 bar called");
+        }
+    }
+}
+
+

--- a/plugins/java-decompiler/engine/testData/src-stdout/javadefault/overloading/TestMethodOverloads.java
+++ b/plugins/java-decompiler/engine/testData/src-stdout/javadefault/overloading/TestMethodOverloads.java
@@ -1,0 +1,87 @@
+package javadefault.overloading;
+
+public class TestMethodOverloads {
+public static class Base {
+	void foo() { System.out.println("Base.foo"); }
+	void bar(Base b) { System.out.println("Base.bar"); }
+	void foobar(SubSub ss) { System.out.println("Base.foobar"); }
+	
+	void test() {
+		System.out.println("\nBase.test running:");
+		SubSub ss = new SubSub();
+		foo();
+		bar(ss);
+		foobar(ss);
+	}
+}
+
+public static class Sub extends Base {
+	void foo() { System.out.println("Sub.foo"); }
+	void bar(Sub s) { System.out.println("Sub.bar"); }
+	void foobar(Sub ss) { System.out.println("Sub.foobar"); }
+	
+	void test() {
+		System.out.println("\nSub.test running:");
+		SubSub ss = new SubSub();
+		foo();
+		System.out.println("2 times the same but different param types:");
+		bar(ss);
+		bar((Base) ss);
+		System.out.println("2 times the same but different param types:");
+		foobar(ss);
+		foobar((Sub) ss);
+	}
+}
+
+public static class SubSub extends Sub {
+	void foo() { System.out.println("SubSub.foo"); }
+	void bar(SubSub s) { System.out.println("SubSub.bar"); }
+	void foobar(Base ss) { System.out.println("SubSub.foobar"); }
+	
+	void test() {
+		System.out.println("\nSubSub.test running:");
+		
+		SubSub ss = new SubSub();
+		foo();
+		bar(ss);
+		System.out.println("3 times the same but different param types:");
+		foobar(ss);
+		//casts needed
+		foobar((Sub) ss);
+		foobar((Base) ss);
+		
+		System.out.println("\nNow cast caller with param SubSub\n");
+		
+		System.out.println("(calls all 3):");
+		((SubSub)this).bar(ss);
+		((Sub)this).bar(ss);
+		((Base)this).bar(ss);
+		System.out.println("(calls 3 times Base):");
+		((SubSub)this).foobar(ss);
+		((Sub)this).foobar(ss);
+		((Base)this).foobar(ss);
+		
+		System.out.println("\nNow cast caller with param Sub\n");
+		
+		Sub s = new Sub();
+		System.out.println("(calls 2*Sub, 1*Base):");
+		((SubSub)this).bar(s);
+		((Sub)this).bar(s);
+		((Base)this).bar(s);
+		System.out.println("(calls * Sub):");
+		((SubSub)this).foobar(s);
+		((Sub)this).foobar(s);
+		//Base.foobar(s);
+	}
+}
+
+static public void test() {
+	new Base().test();
+	new Sub().test();
+	new SubSub().test();
+}
+
+static public void main(String[] args) {
+	test();
+}
+}

--- a/plugins/java-decompiler/engine/testData/src-stdout/javadefault/overloading/TestMethodOverloadsStatic.java
+++ b/plugins/java-decompiler/engine/testData/src-stdout/javadefault/overloading/TestMethodOverloadsStatic.java
@@ -1,0 +1,87 @@
+package javadefault.overloading;
+
+public class TestMethodOverloadsStatic {
+public static class Base {
+	static void foo() { System.out.println("Base.foo"); }
+	static void bar(Base b) { System.out.println("Base.bar"); }
+	static void foobar(SubSub ss) { System.out.println("Base.foobar"); }
+	
+	static void test() {
+		System.out.println("\nBase.test running:");
+		SubSub ss = new SubSub();
+		foo();
+		bar(ss);
+		foobar(ss);
+	}
+}
+
+public static class Sub extends Base {
+	static void foo() { System.out.println("Sub.foo"); }
+	static void bar(Sub s) { System.out.println("Sub.bar"); }
+	static void foobar(Sub ss) { System.out.println("Sub.foobar"); }
+	
+	static void test() {
+		System.out.println("\nSub.test running:");
+		SubSub ss = new SubSub();
+		foo();
+		System.out.println("2 times the same but different param types:");
+		bar(ss);
+		bar((Base) ss);
+		System.out.println("2 times the same but different param types:");
+		foobar(ss);
+		foobar((Sub) ss);
+	}
+}
+
+public static class SubSub extends Sub {
+	static void foo() { System.out.println("SubSub.foo"); }
+	static void bar(SubSub s) { System.out.println("SubSub.bar"); }
+	static void foobar(Base ss) { System.out.println("SubSub.foobar"); }
+	
+	static void test() {
+		System.out.println("\nSubSub.test running:");
+		
+		SubSub ss = new SubSub();
+		foo();
+		bar(ss);
+		System.out.println("3 times the same but different param types:");
+		foobar(ss);
+		//casts needed
+		foobar((Sub) ss);
+		foobar((Base) ss);
+		
+		System.out.println("\nNow call fully qualified with param SubSub\n");
+		
+		System.out.println("again but now fully qualified (calls all 3):");
+		SubSub.bar(ss);
+		Sub.bar(ss);
+		Base.bar(ss);
+		System.out.println("again but now fully qualified (calls 3 times Base):");
+		SubSub.foobar(ss);
+		Sub.foobar(ss);
+		Base.foobar(ss);
+		
+		System.out.println("\nNow call fully qualified with param Sub\n");
+		
+		Sub s = new Sub();
+		System.out.println("again but now fully qualified (calls 2*Sub, 1*Base):");
+		SubSub.bar(s);
+		Sub.bar(s);
+		Base.bar(s);
+		System.out.println("again but now fully qualified (calls * Sub):");
+		SubSub.foobar(s);
+		Sub.foobar(s);
+		//Base.foobar(s);
+	}
+}
+
+public static void test() {
+	Base.test();
+	Sub.test();
+	SubSub.test();
+}
+
+public static void main(String[] args) {
+	test();
+}
+}

--- a/plugins/java-decompiler/engine/testData/src-stdout/javadefault/overloading/TestMethodOverloadsStaticOnInstance.java
+++ b/plugins/java-decompiler/engine/testData/src-stdout/javadefault/overloading/TestMethodOverloadsStaticOnInstance.java
@@ -1,0 +1,87 @@
+package javadefault.overloading;
+
+public class TestMethodOverloadsStaticOnInstance {
+public static class Base {
+	static void foo() { System.out.println("Base.foo"); }
+	static void bar(Base b) { System.out.println("Base.bar"); }
+	static void foobar(SubSub ss) { System.out.println("Base.foobar"); }
+	
+	void test() {
+		System.out.println("\nBase.test running:");
+		SubSub ss = new SubSub();
+		this.foo();
+		this.bar(ss);
+		this.foobar(ss);
+	}
+}
+
+public static class Sub extends Base {
+	static void foo() { System.out.println("Sub.foo"); }
+	static void bar(Sub s) { System.out.println("Sub.bar"); }
+	static void foobar(Sub ss) { System.out.println("Sub.foobar"); }
+	
+	void test() {
+		System.out.println("\nSub.test running:");
+		SubSub ss = new SubSub();
+		this.foo();
+		System.out.println("2 times the same but different param types:");
+		this.bar(ss);
+		this.bar((Base) ss);
+		System.out.println("2 times the same but different param types:");
+		this.foobar(ss);
+		this.foobar((Sub) ss);
+	}
+}
+
+public static class SubSub extends Sub {
+	static void foo() { System.out.println("SubSub.foo"); }
+	static void bar(SubSub s) { System.out.println("SubSub.bar"); }
+	static void foobar(Base ss) { System.out.println("SubSub.foobar"); }
+	
+	void test() {
+		System.out.println("\nSubSub.test running:");
+		
+		SubSub ss = new SubSub();
+		this.foo();
+		this.bar(ss);
+		System.out.println("3 times the same but different param types:");
+		this.foobar(ss);
+		//casts needed
+		this.foobar((Sub) ss);
+		this.foobar((Base) ss);
+		
+		System.out.println("\nNow call fully qualified with param SubSub\n");
+		
+		System.out.println("again but now fully qualified (calls all 3):");
+		((SubSub) this).bar(ss);
+		((Sub) this).bar(ss);
+		((Base) this).bar(ss);
+		System.out.println("again but now fully qualified (calls 3 times Base):");
+		((SubSub) this).foobar(ss);
+		((Sub) this).foobar(ss);
+		((Base) this).foobar(ss);
+		
+		System.out.println("\nNow call fully qualified with param Sub\n");
+		
+		Sub s = new Sub();
+		System.out.println("again but now fully qualified (calls 2*Sub, 1*Base):");
+		((SubSub) this).bar(s);
+		((Sub) this).bar(s);
+		((Base) this).bar(s);
+		System.out.println("again but now fully qualified (calls * Sub):");
+		((SubSub) this).foobar(s);
+		((Sub) this).foobar(s);
+		//Base.foobar(s);
+	}
+}
+
+public static void test() {
+	new Base().test();
+	new Sub().test();
+	new SubSub().test();
+}
+
+public static void main(String[] args) {
+	test();
+}
+}

--- a/plugins/java-decompiler/engine/testData/src-stdout/javadefault/renaming/A.java
+++ b/plugins/java-decompiler/engine/testData/src-stdout/javadefault/renaming/A.java
@@ -1,0 +1,58 @@
+package javadefault.renaming;
+
+/**
+ * renaming did not work for access to .class (used from ClassFieldRenaming.java)
+ */
+public class A {
+
+    public void f() {
+        Class x = A.class;
+        Class y = I.class;
+        Class z = I.J.class;
+        printWhichClass(x);
+        printWhichClass(y);
+        printWhichClass(z);
+    }
+    
+    public static class I {
+        public void f() {
+            Class x = A.class;
+            Class y = I.class;
+            Class z = J.class;
+            
+            Class xa = I[].class;
+            
+            printWhichClass(x);
+            printWhichClass(y);
+            printWhichClass(z);
+            printWhichClass(xa);
+        }
+        
+        public static class J {
+            public void f() {
+                Class x = A.class;
+                Class y = I.class;
+                Class z = J.class;
+                
+                printWhichClass(x);
+                printWhichClass(y);
+                printWhichClass(z);
+            }
+        }
+    }
+    
+    public static void printWhichClass(Object x) {
+      System.out.println("printWhichClass:");
+      System.out.println(new A().getClass().equals(x));
+      System.out.println(new I().getClass().equals(x));
+      System.out.println(new I.J().getClass().equals(x));
+    }
+    
+    /** cannot have real main, renaming of classes would mean this main is no longer found. **/
+    public static void mainXXX(String[] args) {
+      new A().f();
+      new I().f();
+      new I.J().f();
+    }
+}
+

--- a/plugins/java-decompiler/engine/testData/src-stdout/javadefault/renaming/A0_AssertionsAndRenaming.java
+++ b/plugins/java-decompiler/engine/testData/src-stdout/javadefault/renaming/A0_AssertionsAndRenaming.java
@@ -1,0 +1,29 @@
+package javadefault.renaming;
+
+public class A0_AssertionsAndRenaming {
+  public static int i = 1;
+  
+  public int foo() {
+    assert i < 4;
+    System.out.println("AAR.foo");
+    return 1;
+  }
+  
+  public static class X {
+    public int bar() {
+      assert i < 3;
+      System.out.println("AAR.X.bar");
+      return 2;
+    }
+  }
+  
+  public static void main(String[] args) {
+    assert i > 0;
+    A0_AssertionsAndRenaming a = new A0_AssertionsAndRenaming();
+    a.foo();
+    X x = new X();
+    x.bar();
+    A1.mainXXX(args);
+    System.out.println("Done.");
+  }
+}

--- a/plugins/java-decompiler/engine/testData/src-stdout/javadefault/renaming/A1.java
+++ b/plugins/java-decompiler/engine/testData/src-stdout/javadefault/renaming/A1.java
@@ -1,0 +1,33 @@
+package javadefault.renaming;
+
+/**
+ * for AssertionsAndRenaming.java
+ *
+ */
+public class A1 {
+  public static int i = 1;
+  
+  public int foo() {
+    assert i < 4;
+    System.out.println("A1.foo");
+    return 1;
+  }
+  
+  public static class C {
+    public int bar() {
+      assert i < 3;
+      System.out.println("A1.C.bar");
+      return 2;
+    }
+  }
+  
+  /** cannot have real main, renaming of classes would mean this main is no longer found. **/
+  public static void mainXXX(String[] args) {
+    assert i > 0;
+    A1 a = new A1();
+    a.foo();
+    C c = new C();
+    c.bar();
+    System.out.println("A0 Done.");
+  }
+}

--- a/plugins/java-decompiler/engine/testData/src-stdout/javadefault/renaming/A1.java
+++ b/plugins/java-decompiler/engine/testData/src-stdout/javadefault/renaming/A1.java
@@ -28,6 +28,6 @@ public class A1 {
     a.foo();
     C c = new C();
     c.bar();
-    System.out.println("A0 Done.");
+    System.out.println("A1 Done.");
   }
 }

--- a/plugins/java-decompiler/engine/testData/src-stdout/javadefault/renaming/B0_ClassFieldRenaming.java
+++ b/plugins/java-decompiler/engine/testData/src-stdout/javadefault/renaming/B0_ClassFieldRenaming.java
@@ -3,10 +3,10 @@ package javadefault.renaming;
 /**
  * renaming did not work for access to .class
  */
-public class ClassFieldRenaming {
+public class B0_ClassFieldRenaming {
 
     public void f() {
-        Class x = ClassFieldRenaming.class;
+        Class x = B0_ClassFieldRenaming.class;
         Class y = I.class;
         Class z = I.J.class;
         printWhichClass(x);
@@ -16,7 +16,7 @@ public class ClassFieldRenaming {
     
     public static class I {
         public void f() {
-            Class x = ClassFieldRenaming.class;
+            Class x = B0_ClassFieldRenaming.class;
             Class y = I.class;
             Class z = J.class;
             
@@ -30,7 +30,7 @@ public class ClassFieldRenaming {
         
         public static class J {
             public void f() {
-                Class x = ClassFieldRenaming.class;
+                Class x = B0_ClassFieldRenaming.class;
                 Class y = I.class;
                 Class z = J.class;
                 
@@ -43,16 +43,16 @@ public class ClassFieldRenaming {
     
     public static void printWhichClass(Object x) {
       System.out.println("printWhichClass:");
-      System.out.println(new ClassFieldRenaming().getClass().equals(x));
+      System.out.println(new B0_ClassFieldRenaming().getClass().equals(x));
       System.out.println(new I().getClass().equals(x));
       System.out.println(new I.J().getClass().equals(x));
     }
     
     public static void main(String[] args) {
-      new ClassFieldRenaming().f();
+      new B0_ClassFieldRenaming().f();
       new I().f();
       new I.J().f();
-      A.mainXXX(args);
+      B1.mainXXX(args);
     }
 }
 

--- a/plugins/java-decompiler/engine/testData/src-stdout/javadefault/renaming/B1.java
+++ b/plugins/java-decompiler/engine/testData/src-stdout/javadefault/renaming/B1.java
@@ -42,7 +42,7 @@ public class B1 {
     }
     
     public static void printWhichClass(Object x) {
-      System.out.println("printWhichClass:");
+      System.out.println("B1: printWhichClass:");
       System.out.println(new B1().getClass().equals(x));
       System.out.println(new I().getClass().equals(x));
       System.out.println(new I.J().getClass().equals(x));

--- a/plugins/java-decompiler/engine/testData/src-stdout/javadefault/renaming/B1.java
+++ b/plugins/java-decompiler/engine/testData/src-stdout/javadefault/renaming/B1.java
@@ -3,10 +3,10 @@ package javadefault.renaming;
 /**
  * renaming did not work for access to .class (used from ClassFieldRenaming.java)
  */
-public class A {
+public class B1 {
 
     public void f() {
-        Class x = A.class;
+        Class x = B1.class;
         Class y = I.class;
         Class z = I.J.class;
         printWhichClass(x);
@@ -16,7 +16,7 @@ public class A {
     
     public static class I {
         public void f() {
-            Class x = A.class;
+            Class x = B1.class;
             Class y = I.class;
             Class z = J.class;
             
@@ -30,7 +30,7 @@ public class A {
         
         public static class J {
             public void f() {
-                Class x = A.class;
+                Class x = B1.class;
                 Class y = I.class;
                 Class z = J.class;
                 
@@ -43,14 +43,14 @@ public class A {
     
     public static void printWhichClass(Object x) {
       System.out.println("printWhichClass:");
-      System.out.println(new A().getClass().equals(x));
+      System.out.println(new B1().getClass().equals(x));
       System.out.println(new I().getClass().equals(x));
       System.out.println(new I.J().getClass().equals(x));
     }
     
     /** cannot have real main, renaming of classes would mean this main is no longer found. **/
     public static void mainXXX(String[] args) {
-      new A().f();
+      new B1().f();
       new I().f();
       new I.J().f();
     }

--- a/plugins/java-decompiler/engine/testData/src-stdout/javadefault/renaming/ClassFieldRenaming.java
+++ b/plugins/java-decompiler/engine/testData/src-stdout/javadefault/renaming/ClassFieldRenaming.java
@@ -1,0 +1,58 @@
+package javadefault.renaming;
+
+/**
+ * renaming did not work for access to .class
+ */
+public class ClassFieldRenaming {
+
+    public void f() {
+        Class x = ClassFieldRenaming.class;
+        Class y = I.class;
+        Class z = I.J.class;
+        printWhichClass(x);
+        printWhichClass(y);
+        printWhichClass(z);
+    }
+    
+    public static class I {
+        public void f() {
+            Class x = ClassFieldRenaming.class;
+            Class y = I.class;
+            Class z = J.class;
+            
+            Class xa = I[].class;
+            
+            printWhichClass(x);
+            printWhichClass(y);
+            printWhichClass(z);
+            printWhichClass(xa);
+        }
+        
+        public static class J {
+            public void f() {
+                Class x = ClassFieldRenaming.class;
+                Class y = I.class;
+                Class z = J.class;
+                
+                printWhichClass(x);
+                printWhichClass(y);
+                printWhichClass(z);
+            }
+        }
+    }
+    
+    public static void printWhichClass(Object x) {
+      System.out.println("printWhichClass:");
+      System.out.println(new ClassFieldRenaming().getClass().equals(x));
+      System.out.println(new I().getClass().equals(x));
+      System.out.println(new I.J().getClass().equals(x));
+    }
+    
+    public static void main(String[] args) {
+      new ClassFieldRenaming().f();
+      new I().f();
+      new I.J().f();
+      A.mainXXX(args);
+    }
+}
+


### PR DESCRIPTION
(resubmitted, had a git accident..., contributor license agreement on the way...)

For these test you just dump java files into the test folder. They will be compiled, then run (output stored), then the classes are decompiled, compiled and run too (output compared).

So much less maintaining to do then with the other tests (for the others all tests have to be updated on fundamental changes to Fernflower that change decompiled output).

These tests don't require that the decompiler output never changes. They check that the output of the classes when run does not change and is the same as for the original classes. Also we get a failure when the decompiled classes cannot be compiled again.

It also supports optional pattern matching on the created classes. Note: the compiler runs with 'renaming' turned on to test that at the same time.

Classes in 'javadefault' are compiled with Java 1.8, in 'java14' with Java 1.4, in 'java15' with Java 1.5 and so on.

At the moment all but the example test are deactivate (so skipped), see build.xml begin of test-stdout-prepare:

```
<!-- here you can skip tests -->
<patternset id="stdout-tests.exclude.pattern">
  <include name="**/*.java"/>

  <!-- general problems -->
  <!-- non-compilable: causes private field/method access -->
  <exclude name="**/PrivateAccess.java"/>
  <!-- non-compilable: assertion code atm can only handle the throw in the if clause, not in the else clause -->
  <exclude name="**/assertions/**/*"/>
  <!-- overloading causes many troubles... -->
  <exclude name="**/overloading/**/*"/>
  <!-- non-compilable: renaming fails -->
  <exclude name="**/renaming/**/*"/>

  <!-- old java versions -->
  <!-- non-compilable: (.class field trouble with assert) (remove filter on assertions above too) -->
  <exclude name="**/java14/assertions/**/*"/>

</patternset>
```

 See PR 390 in origin repo