### PR TITLE
[Fernflower] Fixed annotations not being renamed properly and corrected the position of annotations relative to generated comments

### DIFF
--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/ClassWriter.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/ClassWriter.java
@@ -299,6 +299,8 @@ public class ClassWriter {
       appendDeprecation(buffer, indent);
     }
 
+    appendAnnotations(buffer, cl, indent);
+
     if (interceptor != null) {
       String oldName = interceptor.getOldName(cl.qualifiedName);
       appendRenameComment(buffer, oldName, MType.CLASS, indent);
@@ -307,8 +309,6 @@ public class ClassWriter {
     if (isSynthetic) {
       appendComment(buffer, "synthetic class", indent);
     }
-
-    appendAnnotations(buffer, cl, indent);
 
     buffer.appendIndent(indent);
 
@@ -395,6 +395,8 @@ public class ClassWriter {
       appendDeprecation(buffer, indent);
     }
 
+    appendAnnotations(buffer, fd, indent);
+
     if (interceptor != null) {
       String oldName = interceptor.getOldName(cl.qualifiedName + " " + fd.getName() + " " + fd.getDescriptor());
       appendRenameComment(buffer, oldName, MType.FIELD, indent);
@@ -403,8 +405,6 @@ public class ClassWriter {
     if (fd.isSynthetic()) {
       appendComment(buffer, "synthetic field", indent);
     }
-
-    appendAnnotations(buffer, fd, indent);
 
     buffer.appendIndent(indent);
 
@@ -611,6 +611,8 @@ public class ClassWriter {
         appendDeprecation(buffer, indent);
       }
 
+      appendAnnotations(buffer, mt, indent);
+
       if (interceptor != null) {
         String oldName = interceptor.getOldName(cl.qualifiedName + " " + mt.getName() + " " + mt.getDescriptor());
         appendRenameComment(buffer, oldName, MType.METHOD, indent);
@@ -624,8 +626,6 @@ public class ClassWriter {
       if (isBridge) {
         appendComment(buffer, "bridge method", indent);
       }
-
-      appendAnnotations(buffer, mt, indent);
 
       buffer.appendIndent(indent);
 

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/struct/attr/StructAnnotationAttribute.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/struct/attr/StructAnnotationAttribute.java
@@ -52,14 +52,14 @@ public class StructAnnotationAttribute extends StructGeneralAttribute {
   }
 
   public static AnnotationExprent parseAnnotation(DataInputStream data, ConstantPool pool) throws IOException {
-    String className = pool.getPrimitiveConstant(data.readUnsignedShort()).getString();
+    String className = pool.getPrimitiveConstant(data.readUnsignedShort(), true).getString();
 
     List<String> names;
     List<Exprent> values;
     int len = data.readUnsignedShort();
     if (len > 0) {
-      names = new ArrayList<String>(len);
-      values = new ArrayList<Exprent>(len);
+      names = new ArrayList<>(len);
+      values = new ArrayList<>(len);
       for (int i = 0; i < len; i++) {
         names.add(pool.getPrimitiveConstant(data.readUnsignedShort()).getString());
         values.add(parseAnnotationElement(data, pool));

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/struct/consts/ConstantPool.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/struct/consts/ConstantPool.java
@@ -184,10 +184,14 @@ public class ConstantPool implements NewClassNameBuilder {
   }
 
   public PrimitiveConstant getPrimitiveConstant(int index) {
+    return getPrimitiveConstant(index, false);
+  }
+
+  public PrimitiveConstant getPrimitiveConstant(int index, boolean ignoreConstantType) {
     PrimitiveConstant cn = (PrimitiveConstant)getConstant(index);
 
     if (cn != null && interceptor != null) {
-      if (cn.type == CodeConstants.CONSTANT_Class) {
+      if (ignoreConstantType || cn.type == CodeConstants.CONSTANT_Class) {
         String newName = buildNewClassname(cn.getString());
         if (newName != null) {
           cn = new PrimitiveConstant(CodeConstants.CONSTANT_Class, newName);


### PR DESCRIPTION
I have previously signed a contributor license agreement.

I fixed a bug that caused annotations to not be properly renamed in the generated source code when the annotation was applied to a class, method, or field.

I also changed it so that generated comments about renamed classes, methods, and fields are placed directly on top of the class, method, or field and below the annotations.

 See PR 367 in origin repo